### PR TITLE
Adding support for evaluating dependencies on Any types

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -30,7 +30,7 @@ type Expression interface {
 	Type(schema schema.Scope, workflowContext map[string][]byte) (schema.Type, error)
 	// Dependencies traverses the passed scope and evaluates the items this expression depends on. This is useful to
 	// construct a dependency tree based on expressions.
-	Dependencies(schema schema.Scope, workflowContext map[string][]byte) ([]Path, error)
+	Dependencies(schema schema.Type, workflowContext map[string][]byte) ([]Path, error)
 	// Evaluate evaluates the expression on the given data set regardless of any
 	// schema. The caller is responsible for validating the expected schema.
 	Evaluate(data any, workflowContext map[string][]byte) (any, error)
@@ -65,7 +65,7 @@ func (e expression) Type(scope schema.Scope, workflowContext map[string][]byte) 
 	return result, nil
 }
 
-func (e expression) Dependencies(scope schema.Scope, workflowContext map[string][]byte) ([]Path, error) {
+func (e expression) Dependencies(scope schema.Type, workflowContext map[string][]byte) ([]Path, error) {
 	tree := &PathTree{
 		PathItem: "$",
 		Subtrees: nil,

--- a/expression_dependencies.go
+++ b/expression_dependencies.go
@@ -132,9 +132,6 @@ func (c *dependencyContext) bracketSubExprMapDependencies(
 	return mapType.Values(), pathItem, nil
 }
 
-// bracketSubExprAnyDependencies is used to resolve dependencies when a bracket accessor has a subexpression,
-// with the left type being an any type.
-
 // bracketSubExprListDependencies is used to resolve dependencies when a bracket accessor has a subexpression,
 // with the left type being a list.
 func (c *dependencyContext) bracketSubExprListDependencies(

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -5,59 +5,83 @@ import (
 
 	"go.arcalot.io/assert"
 	"go.flow.arcalot.io/expressions"
+	"go.flow.arcalot.io/pluginsdk/schema"
 )
 
 func TestDependencyResolution(t *testing.T) {
-	t.Run("object", func(t *testing.T) {
-		expr, err := expressions.New("$.foo.bar")
-		assert.NoError(t, err)
-		path, err := expr.Dependencies(testScope, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, len(path), 1)
-		assert.Equals(t, path[0].String(), "$.foo.bar")
-	})
+	scopes := map[string]schema.Type{
+		"scope": testScope,
+		"any":   schema.NewAnySchema(),
+	}
+	for name, schemaType := range scopes {
+		name := name
+		schemaType := schemaType
+		t.Run(name, func(t *testing.T) {
+			t.Run("object", func(t *testing.T) {
+				expr, err := expressions.New("$.foo.bar")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				assert.NoError(t, err)
+				assert.Equals(t, len(path), 1)
+				assert.Equals(t, path[0].String(), "$.foo.bar")
+			})
 
-	t.Run("map-accessor", func(t *testing.T) {
-		expr, err := expressions.New("$[\"foo\"].bar")
-		assert.NoError(t, err)
-		path, err := expr.Dependencies(testScope, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, len(path), 1)
-		assert.Equals(t, path[0].String(), "$.foo.bar")
-	})
+			t.Run("map-accessor", func(t *testing.T) {
+				expr, err := expressions.New("$[\"foo\"].bar")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				assert.NoError(t, err)
+				assert.Equals(t, len(path), 1)
+				assert.Equals(t, path[0].String(), "$.foo.bar")
+			})
 
-	t.Run("map", func(t *testing.T) {
-		expr, err := expressions.New("$.faz")
-		assert.NoError(t, err)
-		path, err := expr.Dependencies(testScope, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, len(path), 1)
-		assert.Equals(t, path[0].String(), "$.faz")
-	})
+			t.Run("map", func(t *testing.T) {
+				expr, err := expressions.New("$.faz")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				assert.NoError(t, err)
+				assert.Equals(t, len(path), 1)
+				assert.Equals(t, path[0].String(), "$.faz")
+			})
 
-	t.Run("map-subkey", func(t *testing.T) {
-		expr, err := expressions.New("$.faz.foo")
-		assert.NoError(t, err)
-		path, err := expr.Dependencies(testScope, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, len(path), 1)
-		assert.Equals(t, path[0].String(), "$.faz.foo")
-	})
+			t.Run("map-subkey", func(t *testing.T) {
+				expr, err := expressions.New("$.faz.foo")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				assert.NoError(t, err)
+				assert.Equals(t, len(path), 1)
+				assert.Equals(t, path[0].String(), "$.faz.foo")
+			})
+			t.Run("subexpression-invalid", func(t *testing.T) {
+				expr, err := expressions.New("$.foo[($.faz.foo)]")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				if name == "scope" {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Equals(t, path[0].String(), "$.foo")
+					assert.Equals(t, path[1].String(), "$.faz.foo")
+				}
+			})
 
-	t.Run("subexpression-invalid", func(t *testing.T) {
-		expr, err := expressions.New("$.foo[($.faz.foo)]")
-		assert.NoError(t, err)
-		_, err = expr.Dependencies(testScope, nil)
-		assert.Error(t, err)
-	})
+			t.Run("subexpression", func(t *testing.T) {
+				expr, err := expressions.New("$.faz[($.foo.bar)]")
+				assert.NoError(t, err)
+				path, err := expr.Dependencies(schemaType, nil)
+				if name == "scope" {
+					assert.NoError(t, err)
+					assert.Equals(t, len(path), 2)
+					assert.Equals(t, path[0].String(), "$.faz.*")
+					assert.Equals(t, path[1].String(), "$.foo.bar")
+				} else {
+					assert.NoError(t, err)
+					assert.Equals(t, len(path), 2)
+					assert.Equals(t, path[0].String(), "$.faz")
+					assert.Equals(t, path[1].String(), "$.foo.bar")
+				}
+			})
+		})
+	}
 
-	t.Run("subexpression", func(t *testing.T) {
-		expr, err := expressions.New("$.faz[($.foo.bar)]")
-		assert.NoError(t, err)
-		path, err := expr.Dependencies(testScope, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, len(path), 2)
-		assert.Equals(t, path[0].String(), "$.faz.*")
-		assert.Equals(t, path[1].String(), "$.foo.bar")
-	})
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds support for evaluating expression dependencies on any types. This is useful for referencing an any type, or for speculatively evaluating expressions when the type is not yet known.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).