### PR TITLE
Improved dependency resolution

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -63,11 +63,11 @@ func (e expression) Type(scope schema.Scope, functions map[string]schema.Functio
 		workflowContext: workflowContext,
 		functions:       functions,
 	}
-	result, _, _, err := d.rootDependencies(e.ast)
+	dependencyResolutionResult, err := d.rootDependencies(e.ast)
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return dependencyResolutionResult.resolvedType, nil
 }
 
 func (e expression) Dependencies(
@@ -86,13 +86,13 @@ func (e expression) Dependencies(
 		workflowContext: workflowContext,
 		functions:       functions,
 	}
-	_, _, dependencies, err := d.rootDependencies(e.ast)
+	dependencyResolutionResult, err := d.rootDependencies(e.ast)
 	if err != nil {
 		return nil, err
 	}
 	// Now convert to paths, saving only unique values.
 	finalDependencyMap := make(map[string]Path)
-	for _, dependencyTree := range dependencies {
+	for _, dependencyTree := range dependencyResolutionResult.completedPaths {
 		unpackedDependencies := dependencyTree.Unpack(includeExtraneous)
 		for _, dependency := range unpackedDependencies {
 			asString := dependency.String()

--- a/expression.go
+++ b/expression.go
@@ -92,22 +92,18 @@ func (e expression) Dependencies(
 		return nil, err
 	}
 	// Now convert to paths, saving only unique values.
-	finalDependencyMap := make(map[string]Path)
+	finalDependencySet := make(map[string]bool)
+	finalDependencies := make([]Path, 0)
 	for _, dependencyTree := range dependencyResolutionResult.completedPaths {
 		unpackedDependencies := dependencyTree.Unpack(unpackRequirements)
 		for _, dependency := range unpackedDependencies {
 			asString := dependency.String()
-			_, dependencyExists := finalDependencyMap[asString]
+			_, dependencyExists := finalDependencySet[asString]
 			if !dependencyExists {
-				finalDependencyMap[asString] = dependency
+				finalDependencies = append(finalDependencies, dependency)
+				finalDependencySet[asString] = true
 			}
 		}
-	}
-	finalDependencies := make([]Path, len(finalDependencyMap))
-	i := 0
-	for _, v := range finalDependencyMap {
-		finalDependencies[i] = v
-		i += 1
 	}
 	return finalDependencies, nil
 }

--- a/expression.go
+++ b/expression.go
@@ -32,9 +32,8 @@ type Expression interface {
 	// construct a dependency tree based on expressions.
 	// Returns the path to the object in the schema that it depends on, or nil if it's a literal that doesn't depend
 	// on it.
-	// includeExtraneous specifies whether to include things not explicitly present in the schema, like values within
-	// any types, or indexes in lists.
-	Dependencies(schema schema.Type, functions map[string]schema.Function, workflowContext map[string][]byte, includeExtraneous bool) ([]Path, error)
+	// unpackRequirements specifies which paths to include, and which values to include in paths.
+	Dependencies(schema schema.Type, functions map[string]schema.Function, workflowContext map[string][]byte, unapackRequirements UnpackRequirements) ([]Path, error)
 	// Evaluate evaluates the expression on the given data set regardless of any
 	// schema. The caller is responsible for validating the expected schema.
 	Evaluate(data any, functions map[string]schema.CallableFunction, workflowContext map[string][]byte) (any, error)
@@ -55,6 +54,7 @@ func (e expression) String() string {
 func (e expression) Type(scope schema.Scope, functions map[string]schema.Function, workflowContext map[string][]byte) (schema.Type, error) {
 	tree := PathTree{
 		PathItem: "$",
+		NodeType: DataRootNode,
 		Subtrees: nil,
 	}
 	d := &dependencyContext{
@@ -74,10 +74,11 @@ func (e expression) Dependencies(
 	scope schema.Type,
 	functions map[string]schema.Function,
 	workflowContext map[string][]byte,
-	includeExtraneous bool,
+	unpackRequirements UnpackRequirements,
 ) ([]Path, error) {
 	root := PathTree{
 		PathItem: "$",
+		NodeType: DataRootNode,
 		Subtrees: nil,
 	}
 	d := &dependencyContext{
@@ -93,7 +94,7 @@ func (e expression) Dependencies(
 	// Now convert to paths, saving only unique values.
 	finalDependencyMap := make(map[string]Path)
 	for _, dependencyTree := range dependencyResolutionResult.completedPaths {
-		unpackedDependencies := dependencyTree.Unpack(includeExtraneous)
+		unpackedDependencies := dependencyTree.Unpack(unpackRequirements)
 		for _, dependency := range unpackedDependencies {
 			asString := dependency.String()
 			_, dependencyExists := finalDependencyMap[asString]

--- a/expression.go
+++ b/expression.go
@@ -33,7 +33,7 @@ type Expression interface {
 	// Returns the path to the object in the schema that it depends on, or nil if it's a literal that doesn't depend
 	// on it.
 	// unpackRequirements specifies which paths to include, and which values to include in paths.
-	Dependencies(schema schema.Type, functions map[string]schema.Function, workflowContext map[string][]byte, unapackRequirements UnpackRequirements) ([]Path, error)
+	Dependencies(schema schema.Type, functions map[string]schema.Function, workflowContext map[string][]byte, unpackRequirements UnpackRequirements) ([]Path, error)
 	// Evaluate evaluates the expression on the given data set regardless of any
 	// schema. The caller is responsible for validating the expected schema.
 	Evaluate(data any, functions map[string]schema.CallableFunction, workflowContext map[string][]byte) (any, error)

--- a/expression_data_test.go
+++ b/expression_data_test.go
@@ -67,6 +67,20 @@ var testScope = schema.NewScopeSchema(
 				nil,
 				nil,
 			),
+			"int_list": schema.NewPropertySchema(
+				schema.NewListSchema(
+					schema.NewIntSchema(nil, nil, nil),
+					nil,
+					nil,
+				),
+				nil,
+				true,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
 		},
 	),
 )

--- a/expression_data_test.go
+++ b/expression_data_test.go
@@ -67,6 +67,16 @@ var testScope = schema.NewScopeSchema(
 				nil,
 				nil,
 			),
+			"simple_any": schema.NewPropertySchema(
+				schema.NewAnySchema(),
+				nil,
+				true,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
 			"int_list": schema.NewPropertySchema(
 				schema.NewListSchema(
 					schema.NewIntSchema(nil, nil, nil),

--- a/expression_dependencies.go
+++ b/expression_dependencies.go
@@ -15,19 +15,44 @@ type dependencyContext struct {
 	functions       map[string]schema.Function
 }
 
+type dependencyResult struct {
+	resolvedType   schema.Type
+	chainablePath  *PathTree
+	completedPaths []*PathTree
+}
+
+func (d *dependencyResult) addCompletedDependencies(newCompletedPaths []*PathTree) {
+	d.completedPaths = append(d.completedPaths, newCompletedPaths...)
+}
+func (d *dependencyResult) addCompletedDependency(newCompletedPath *PathTree) {
+	d.completedPaths = append(d.completedPaths, newCompletedPath)
+}
+
+func newDependencyResult(t schema.Type, chainablePath *PathTree) *dependencyResult {
+	return &dependencyResult{
+		resolvedType:   t,
+		chainablePath:  chainablePath,
+		completedPaths: []*PathTree{},
+	}
+}
+
+func newUnchainableDependencyResult(t schema.Type) *dependencyResult {
+	return newDependencyResult(t, nil)
+}
+
 func (c *dependencyContext) rootDependencies(
 	node ast.Node,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	newRoot := c.rootPath
-	resolvedType, chainablePath, dependencies, err := c.dependencies(node, c.rootType, &newRoot)
+	result, err := c.dependencies(node, c.rootType, &newRoot)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	// Non-chainable types do not have a resultant dependency.
-	if chainablePath != nil {
-		dependencies = append(dependencies, &newRoot)
+	if result.chainablePath != nil {
+		result.addCompletedDependency(&newRoot)
 	}
-	return resolvedType, chainablePath, dependencies, nil
+	return result, nil
 }
 
 // dependencies evaluates an AST node for possible dependencies. It adds items to the specified path tree and returns
@@ -47,7 +72,7 @@ func (c *dependencyContext) dependencies(
 	node ast.Node,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	switch n := node.(type) {
 	case *ast.DotNotation:
 		return c.dotNotationDependencies(n, currentType, path)
@@ -56,28 +81,28 @@ func (c *dependencyContext) dependencies(
 	case *ast.Identifier:
 		return c.identifierDependencies(n, currentType, path)
 	case *ast.StringLiteral:
-		return schema.NewStringSchema(nil, nil, nil), nil, []*PathTree{}, nil
+		return newUnchainableDependencyResult(schema.NewStringSchema(nil, nil, nil)), nil
 	case *ast.IntLiteral:
-		return schema.NewIntSchema(nil, nil, nil), nil, []*PathTree{}, nil
+		return newUnchainableDependencyResult(schema.NewIntSchema(nil, nil, nil)), nil
 	case *ast.FunctionCall:
 		return c.functionDependencies(n)
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported AST node type: %T", n)
+		return nil, fmt.Errorf("unsupported AST node type: %T", n)
 	}
 }
 
 // Note: A function itself doesn't have a path dependency, but its args could.
 // Therefore, it cannot be chained, so it doesn't return that type.
-func (c *dependencyContext) functionDependencies(node *ast.FunctionCall) (schema.Type, *PathTree, []*PathTree, error) {
+func (c *dependencyContext) functionDependencies(node *ast.FunctionCall) (*dependencyResult, error) {
 	// Get the types and dependencies of all parameters.
 	functionSchema, found := c.functions[node.FuncIdentifier.IdentifierName]
 	if !found {
-		return nil, nil, nil, fmt.Errorf("could not find function '%s'", node.FuncIdentifier.IdentifierName)
+		return nil, fmt.Errorf("could not find function '%s'", node.FuncIdentifier.IdentifierName)
 	}
 	paramTypes := functionSchema.Parameters()
 	// Validate param count
 	if node.ArgumentInputs.NumChildren() != len(paramTypes) {
-		return nil, nil, nil, fmt.Errorf("invalid call to function '%s'. Expected %d args, got %d args. Function schema: %s",
+		return nil, fmt.Errorf("invalid call to function '%s'. Expected %d args, got %d args. Function schema: %s",
 			functionSchema.ID(), len(paramTypes), node.ArgumentInputs.NumChildren(), functionSchema.String())
 	}
 	// Types need to be saved to validate argument types with parameter types, which are also needed to get the output type.
@@ -87,26 +112,30 @@ func (c *dependencyContext) functionDependencies(node *ast.FunctionCall) (schema
 	argTypes := make([]schema.Type, 0)
 	for i := 0; i < len(node.ArgumentInputs.Arguments); i++ {
 		arg := node.ArgumentInputs.Arguments[i]
-		argType, _, argDependencies, err := c.rootDependencies(arg)
+		argResult, err := c.rootDependencies(arg)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		// Validate type compatibility with function's schema
 		paramType := paramTypes[i]
-		if err := paramType.ValidateCompatibility(argType); err != nil {
-			return nil, nil, nil, fmt.Errorf("error while validating arg/param type compatibility for function '%s' at 0-index %d (%w). Function schema: %s",
+		if err := paramType.ValidateCompatibility(argResult.resolvedType); err != nil {
+			return nil, fmt.Errorf("error while validating arg/param type compatibility for function '%s' at 0-index %d (%w). Function schema: %s",
 				functionSchema.ID(), i, err, functionSchema.String())
 		}
-		argTypes = append(argTypes, argType)
+		argTypes = append(argTypes, argResult.resolvedType)
 		// Add dependency to the path tree
-		dependencies = append(dependencies, argDependencies...)
+		dependencies = append(dependencies, argResult.completedPaths...)
 	}
 	// Now get the type from the function output
 	outputType, _, err := functionSchema.Output(argTypes)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error while getting return type (%w)", err)
+		return nil, fmt.Errorf("error while getting return type (%w)", err)
 	}
-	return outputType, nil, dependencies, nil
+	return &dependencyResult{
+		resolvedType:   outputType,
+		chainablePath:  nil,
+		completedPaths: dependencies,
+	}, nil
 }
 
 // dotNotationDependencies resolves dependencies of a DotNotation node.
@@ -117,23 +146,27 @@ func (c *dependencyContext) dotNotationDependencies(
 	node *ast.DotNotation,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	// Theoretical scenario, the left is a function call. It's dependencies are all that matter.
 	// Alternative scenario, the left is an instance of access to the main data structure. In this case, it is its
 	// own dependency.
 	// Start with the left access.
-	leftType, leftChainablePath, leftDependencies, err := c.dependencies(node.LeftAccessibleNode, currentType, path)
+	leftResult, err := c.dependencies(node.LeftAccessibleNode, currentType, path)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	// Right dependencies, using left type.
-	rightType, rightChainablePath, rightDependencies, err := c.dependencies(node.RightAccessIdentifier, leftType, leftChainablePath)
+	rightResult, err := c.dependencies(node.RightAccessIdentifier, leftResult.resolvedType, leftResult.chainablePath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	// If the left isn't chainable, we use include its dependencies.
-	finalDependencies := append(rightDependencies, leftDependencies...)
-	return rightType, rightChainablePath, finalDependencies, nil
+	finalDependencies := append(rightResult.completedPaths, leftResult.completedPaths...)
+	return &dependencyResult{
+		resolvedType:   rightResult.resolvedType,
+		chainablePath:  rightResult.chainablePath,
+		completedPaths: finalDependencies,
+	}, nil
 }
 
 // bracketAccessorDependencies resolves dependencies for a BracketAccessor node,
@@ -142,42 +175,40 @@ func (c *dependencyContext) bracketAccessorDependencies(
 	node *ast.BracketAccessor,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	// A bracket accessor is when an item[item] is encountered. Here we need to evaluate the left tree as usual, then
 	// use the right tree according to its type. This is either a literal (e.g. a string), or it is a subexpression.
 	// Literals will call dependenciesMapKey, while subexpressions need to be evaluated on their own on the root
 	// type.
-	leftType, leftPath, leftDependencies, err := c.dependencies(node.LeftNode, currentType, path)
+	leftResult, err := c.dependencies(node.LeftNode, currentType, path)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	// Evaluate the subexpression
-	keyType, _, keyDependencies, err := c.rootDependencies(node.RightExpression)
+	keyResult, err := c.rootDependencies(node.RightExpression)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
-	mergedDependencies := append(leftDependencies, keyDependencies...)
-	var typeResult schema.Type
-	var chainablePath *PathTree
-	var currentDependencies []*PathTree
-	switch leftType.TypeID() {
+	mergedDependencies := append(leftResult.completedPaths, keyResult.completedPaths...)
+	var overallResult *dependencyResult
+	switch leftResult.resolvedType.TypeID() {
 	case schema.TypeIDMap:
-		typeResult, chainablePath, currentDependencies, err = c.bracketSubExprMapDependencies(keyType, leftType, leftPath)
+		overallResult, err = c.bracketSubExprMapDependencies(keyResult.resolvedType, leftResult.resolvedType, leftResult.chainablePath)
 	case schema.TypeIDList:
-		typeResult, chainablePath, currentDependencies, err = c.bracketListDependencies(keyType, leftType, leftPath)
+		overallResult, err = c.bracketListDependencies(keyResult.resolvedType, leftResult.resolvedType, leftResult.chainablePath)
 	case schema.TypeIDAny:
-		typeResult, chainablePath, currentDependencies, err = schema.NewAnySchema(), leftPath, []*PathTree{}, nil
+		overallResult, err = &dependencyResult{schema.NewAnySchema(), leftResult.chainablePath, []*PathTree{}}, nil
 	default:
 		// We don't support subexpressions to pick a property on an object type since that would result in
 		// unpredictable behavior and runtime errors. Furthermore, we would not be able to perform type
 		// evaluation.
-		return nil, nil, nil, fmt.Errorf("subexpressions are only supported on map, list, and any types, %s given", currentType.TypeID())
+		return nil, fmt.Errorf("subexpressions are only supported on map, list, and any types, %s given", currentType.TypeID())
 	}
 	// For literals, add extraneous data.
-	chainablePath = c.addExtraneous(node.RightExpression, chainablePath)
-	mergedDependencies = append(mergedDependencies, currentDependencies...)
-	return typeResult, chainablePath, mergedDependencies, err
+	overallResult.chainablePath = c.addExtraneous(node.RightExpression, overallResult.chainablePath)
+	overallResult.addCompletedDependencies(mergedDependencies)
+	return overallResult, err
 }
 
 // bracketSubExprMapDependencies is used to resolve dependencies when a bracket accessor has a subexpression,
@@ -186,15 +217,15 @@ func (c *dependencyContext) bracketSubExprMapDependencies(
 	keyType schema.Type,
 	leftType schema.Type,
 	leftPath *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	// For maps, we try to compare the type of the map key with the resulting type of the subexpression to
 	// make sure that there are no runtime type failures. The user may need to add type conversion functions
 	// to their expressions to convert an integer to a string, for example.
 	mapType := leftType.(schema.UntypedMap)
 	if keyType.TypeID() != mapType.Keys().TypeID() {
-		return nil, nil, nil, fmt.Errorf("subexpression evaluates to type '%s' for a map, '%s' expected", keyType.TypeID(), mapType.Keys().TypeID())
+		return nil, fmt.Errorf("subexpression evaluates to type '%s' for a map, '%s' expected", keyType.TypeID(), mapType.Keys().TypeID())
 	}
-	return mapType.Values(), leftPath, []*PathTree{}, nil
+	return newDependencyResult(mapType.Values(), leftPath), nil
 }
 
 // bracketListDependencies is used to resolve dependencies when a bracket accessor has a subexpression,
@@ -203,16 +234,16 @@ func (c *dependencyContext) bracketListDependencies(
 	keyType schema.Type,
 	leftType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	// Lists have integer indexes, so we try to make sure that the subexpression is yielding an int or
 	// int-like type. This will have the best chance of not resulting in a runtime error.
 	list := leftType.(schema.UntypedList)
 	switch keyType.TypeID() {
 	case schema.TypeIDInt:
 	default:
-		return nil, nil, nil, fmt.Errorf("subexpressions resulted in a %s type for a list key, integer expected", keyType.TypeID())
+		return nil, fmt.Errorf("subexpressions resulted in a %s type for a list key, integer expected", keyType.TypeID())
 	}
-	return list.Items(), path, []*PathTree{}, nil
+	return newDependencyResult(list.Items(), path), nil
 }
 
 func (c *dependencyContext) addExtraneous(node ast.Node, path *PathTree) *PathTree {
@@ -237,15 +268,15 @@ func (c *dependencyContext) identifierDependencies(
 	node *ast.Identifier,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	switch node.IdentifierName {
 	case "$":
 		// This identifier means the root of the expression.
 		// Validate that the given path is actually at the root.
 		if path.PathItem != "$" {
-			return nil, nil, nil, fmt.Errorf("root access chained after non-root")
+			return nil, fmt.Errorf("root access chained after non-root")
 		}
-		return c.rootType, path, []*PathTree{}, nil
+		return newDependencyResult(c.rootType, path), nil
 	default:
 		// This case is the item.item type expression, where the right item is the "identifier" in question.
 		return dependenciesAccessObject(currentType, node.IdentifierName, path)
@@ -258,7 +289,7 @@ func dependenciesAccessObject(
 	leftType schema.Type,
 	identifier string,
 	path *PathTree,
-) (schema.Type, *PathTree, []*PathTree, error) {
+) (*dependencyResult, error) {
 	switch leftType.TypeID() {
 	case schema.TypeIDScope, schema.TypeIDRef, schema.TypeIDObject:
 		// Object-likes always have field names (strings) as keys, so we need to convert the passed value to a string.
@@ -267,7 +298,7 @@ func dependenciesAccessObject(
 		properties := currentObject.Properties()
 		property, ok := properties[identifier]
 		if !ok {
-			return nil, nil, nil, fmt.Errorf("object %s does not have a property named %q", currentObject.ID(), identifier)
+			return nil, fmt.Errorf("object %s does not have a property named %q", currentObject.ID(), identifier)
 		}
 		pathItem := &PathTree{
 			PathItem:     identifier,
@@ -277,7 +308,7 @@ func dependenciesAccessObject(
 		if path != nil {
 			path.Subtrees = append(path.Subtrees, pathItem)
 		}
-		return property.Type(), pathItem, []*PathTree{}, nil
+		return newDependencyResult(property.Type(), pathItem), nil
 	case schema.TypeIDAny:
 		// We're accessing an unvalidated field, because the type is 'any.
 		// So mark the subtree as extraneous.
@@ -289,9 +320,8 @@ func dependenciesAccessObject(
 		if path != nil {
 			path.Subtrees = append(path.Subtrees, pathItem)
 		}
-		return schema.NewAnySchema(), pathItem, []*PathTree{}, nil
+		return newDependencyResult(schema.NewAnySchema(), pathItem), nil
 	default:
-		return nil, nil, nil,
-			fmt.Errorf("cannot evaluate expression identifier %s on data type %s", identifier, leftType.TypeID())
+		return nil, fmt.Errorf("cannot evaluate expression identifier %s on data type %s", identifier, leftType.TypeID())
 	}
 }

--- a/expression_dependencies.go
+++ b/expression_dependencies.go
@@ -160,7 +160,6 @@ func (c *dependencyContext) dotNotationDependencies(
 	if err != nil {
 		return nil, err
 	}
-	// If the left isn't chainable, we use include its dependencies.
 	finalDependencies := append(rightResult.completedPaths, leftResult.completedPaths...)
 	return &dependencyResult{
 		resolvedType:   rightResult.resolvedType,
@@ -255,9 +254,7 @@ func (c *dependencyContext) addExtraneous(node ast.Node, path *PathTree) *PathTr
 				IsExtraneous: true,
 				Subtrees:     nil,
 			}
-			if path != nil {
-				path.Subtrees = append(path.Subtrees, pathItem)
-			}
+			path.Subtrees = append(path.Subtrees, pathItem) // A nil check was done earlier.
 			return pathItem
 		}
 	}
@@ -310,7 +307,7 @@ func dependenciesAccessObject(
 		}
 		return newDependencyResult(property.Type(), pathItem), nil
 	case schema.TypeIDAny:
-		// We're accessing an unvalidated field, because the type is 'any.
+		// We're accessing an unvalidated field, because the type is 'any'.
 		// So mark the subtree as extraneous.
 		pathItem := &PathTree{
 			PathItem:     identifier,

--- a/expression_dependencies.go
+++ b/expression_dependencies.go
@@ -152,14 +152,6 @@ func (c *dependencyContext) bracketAccessorDependencies(
 		return nil, nil, nil, err
 	}
 
-	/*if literal, ok := node.RightExpression.(ast.ValueLiteral); ok {
-		return dependenciesAccessKnownKey(leftType, literal.Value(), leftPath)
-	} else {*/
-
-	// If we have a subexpression, we need to add all possible keys to the dependency map since we can't
-	// determine the correct one to extract. This could be further refined by evaluating the type. If it is an
-	// enum, we could potentially limit the number of dependencies.
-
 	// Evaluate the subexpression
 	keyType, _, keyDependencies, err := c.rootDependencies(node.RightExpression)
 	if err != nil {

--- a/expression_dependencies.go
+++ b/expression_dependencies.go
@@ -12,9 +12,24 @@ import (
 // don't need to pass the root type, path, and workflow context along with each function call.
 type dependencyContext struct {
 	rootType        schema.Type
-	rootPath        *PathTree
+	rootPath        PathTree
 	workflowContext map[string][]byte
 	functions       map[string]schema.Function
+}
+
+func (c *dependencyContext) rootDependencies(
+	node ast.Node,
+) (schema.Type, *PathTree, []*PathTree, error) {
+	newRoot := c.rootPath
+	resolvedType, chainablePath, dependencies, err := c.dependencies(node, c.rootType, &newRoot)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// Non-chainable types do not have a resultant dependency.
+	if chainablePath != nil {
+		dependencies = append(dependencies, &newRoot)
+	}
+	return resolvedType, chainablePath, dependencies, nil
 }
 
 // dependencies evaluates an AST node for possible dependencies. It adds items to the specified path tree and returns
@@ -24,16 +39,17 @@ type dependencyContext struct {
 // Arguments:
 // - node: The root node of the tree of sub-tree to evaluate.
 // - currentType: The schema, which specifies the values and their types that can be referenced.
-// - path: A reference to the PathTree to the current node, which gets added to with the dependencies.
+// - path: A reference to the PathTree to the current node, which will have sub-trees added to it.
 // Returns:
-// - schema.Type: The schema for the value.
-// - *PathTree, the path to the value it depends on in the input schema, or nil if it's a literal.
-// - error: An error, if encountered.
+//   - schema.Type: The schema for the value.
+//   - *PathTree, the chainable path to the subtree node that can be built upon.
+//   - []*PathTree, the path to the values this node depends on in the input schema. Empty if it's a literal.
+//   - error: An error, if encountered.
 func (c *dependencyContext) dependencies(
 	node ast.Node,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, error) {
+) (schema.Type, *PathTree, []*PathTree, error) {
 	switch n := node.(type) {
 	case *ast.DotNotation:
 		return c.dotNotationDependencies(n, currentType, path)
@@ -42,58 +58,57 @@ func (c *dependencyContext) dependencies(
 	case *ast.Identifier:
 		return c.identifierDependencies(n, currentType, path)
 	case *ast.StringLiteral:
-		return schema.NewStringSchema(nil, nil, nil), nil, nil
+		return schema.NewStringSchema(nil, nil, nil), nil, []*PathTree{}, nil
 	case *ast.IntLiteral:
-		return schema.NewIntSchema(nil, nil, nil), nil, nil
+		return schema.NewIntSchema(nil, nil, nil), nil, []*PathTree{}, nil
 	case *ast.FunctionCall:
 		return c.functionDependencies(n)
 	default:
-		return nil, nil, fmt.Errorf("unsupported AST node type: %T", n)
+		return nil, nil, nil, fmt.Errorf("unsupported AST node type: %T", n)
 	}
 }
 
-func (c *dependencyContext) functionDependencies(node *ast.FunctionCall) (schema.Type, *PathTree, error) {
+// Note: A function itself doesn't have a path dependency, but its args could.
+// Therefore, it cannot be chained, so it doesn't return that type.
+func (c *dependencyContext) functionDependencies(node *ast.FunctionCall) (schema.Type, *PathTree, []*PathTree, error) {
 	// Get the types and dependencies of all parameters.
 	functionSchema, found := c.functions[node.FuncIdentifier.IdentifierName]
 	if !found {
-		return nil, nil, fmt.Errorf("could not find function '%s'", node.FuncIdentifier.IdentifierName)
+		return nil, nil, nil, fmt.Errorf("could not find function '%s'", node.FuncIdentifier.IdentifierName)
 	}
 	paramTypes := functionSchema.Parameters()
 	// Validate param count
 	if node.ArgumentInputs.NumChildren() != len(paramTypes) {
-		return nil, nil, fmt.Errorf("invalid call to function '%s'. Expected %d args, got %d args. Function schema: %s",
+		return nil, nil, nil, fmt.Errorf("invalid call to function '%s'. Expected %d args, got %d args. Function schema: %s",
 			functionSchema.ID(), len(paramTypes), node.ArgumentInputs.NumChildren(), functionSchema.String())
 	}
 	// Types need to be saved to validate argument types with parameter types, which are also needed to get the output type.
 	// Dependencies need to also be added to the PathTree
-	newFuncArgsPath := &PathTree{
-		PathItem: node.FuncIdentifier.IdentifierName,
-		Subtrees: nil,
-	}
+	dependencies := make([]*PathTree, 0)
 	// Save arg types for passing into output function
 	argTypes := make([]schema.Type, 0)
 	for i := 0; i < len(node.ArgumentInputs.Arguments); i++ {
 		arg := node.ArgumentInputs.Arguments[i]
-		argType, argDependencies, err := c.dependencies(arg, c.rootType, c.rootPath)
+		argType, _, argDependencies, err := c.rootDependencies(arg)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		// Validate type compatibility with function's schema
 		paramType := paramTypes[i]
 		if err := paramType.ValidateCompatibility(argType); err != nil {
-			return nil, nil, fmt.Errorf("error while validating arg/param type compatibility for function '%s' at 0-index %d (%w). Function schema: %s",
+			return nil, nil, nil, fmt.Errorf("error while validating arg/param type compatibility for function '%s' at 0-index %d (%w). Function schema: %s",
 				functionSchema.ID(), i, err, functionSchema.String())
 		}
 		argTypes = append(argTypes, argType)
 		// Add dependency to the path tree
-		newFuncArgsPath.Subtrees = append(newFuncArgsPath.Subtrees, argDependencies)
+		dependencies = append(dependencies, argDependencies...)
 	}
 	// Now get the type from the function output
 	outputType, _, err := functionSchema.Output(argTypes)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error while getting return type (%w)", err)
+		return nil, nil, nil, fmt.Errorf("error while getting return type (%w)", err)
 	}
-	return outputType, newFuncArgsPath, nil
+	return outputType, nil, dependencies, nil
 }
 
 // dotNotationDependencies resolves dependencies of a DotNotation node.
@@ -104,14 +119,23 @@ func (c *dependencyContext) dotNotationDependencies(
 	node *ast.DotNotation,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, error) {
-	// Left dependencies
-	leftType, leftPath, err := c.dependencies(node.LeftAccessibleNode, currentType, path)
+) (schema.Type, *PathTree, []*PathTree, error) {
+	// Theoretical scenario, the left is a function call. It's dependencies are all that matter.
+	// Alternative scenario, the left is an instance of access to the main data structure. In this case, it is its
+	// own dependency.
+	// Start with the left access.
+	leftType, leftChainablePath, leftDependencies, err := c.dependencies(node.LeftAccessibleNode, currentType, path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Right dependencies, using left type.
-	return c.dependencies(node.RightAccessIdentifier, leftType, leftPath)
+	rightType, rightChainablePath, rightDependencies, err := c.dependencies(node.RightAccessIdentifier, leftType, leftChainablePath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// If the left isn't chainable, we use include its dependencies.
+	finalDependencies := append(rightDependencies, leftDependencies...)
+	return rightType, rightChainablePath, finalDependencies, nil
 }
 
 // bracketAccessorDependencies resolves dependencies for a BracketAccessor node,
@@ -120,14 +144,14 @@ func (c *dependencyContext) bracketAccessorDependencies(
 	node *ast.BracketAccessor,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, error) {
+) (schema.Type, *PathTree, []*PathTree, error) {
 	// A bracket accessor is when an item[item] is encountered. Here we need to evaluate the left tree as usual, then
 	// use the right tree according to its type. This is either a literal (e.g. a string), or it is a subexpression.
 	// Literals will call dependenciesMapKey, while subexpressions need to be evaluated on their own on the root
 	// type.
-	leftType, leftPath, err := c.dependencies(node.LeftNode, currentType, path)
+	leftType, leftPath, leftDependencies, err := c.dependencies(node.LeftNode, currentType, path)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if literal, ok := node.RightExpression.(ast.ValueLiteral); ok {
@@ -139,23 +163,29 @@ func (c *dependencyContext) bracketAccessorDependencies(
 		// enum, we could potentially limit the number of dependencies.
 
 		// Evaluate the subexpression
-		keyType, _, err := c.dependencies(node.RightExpression, c.rootType, c.rootPath)
+		keyType, _, keyDependencies, err := c.rootDependencies(node.RightExpression)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+		mergedDependencies := append(leftDependencies, keyDependencies...)
+		var typeResult schema.Type
+		var chainablePath *PathTree
+		var currentDependencies []*PathTree
 		switch leftType.TypeID() {
 		case schema.TypeIDMap:
-			return c.bracketSubExprMapDependencies(keyType, leftType, leftPath)
+			typeResult, chainablePath, currentDependencies, err = c.bracketSubExprMapDependencies(keyType, leftType, leftPath)
 		case schema.TypeIDList:
-			return c.bracketSubExprListDependencies(keyType, leftType, leftPath)
+			typeResult, chainablePath, currentDependencies, err = c.bracketSubExprListDependencies(keyType, leftType, leftPath)
 		case schema.TypeIDAny:
-			return schema.NewAnySchema(), leftPath, nil
+			typeResult, chainablePath, currentDependencies, err = schema.NewAnySchema(), leftPath, []*PathTree{}, nil
 		default:
 			// We don't support subexpressions to pick a property on an object type since that would result in
 			// unpredictable behavior and runtime errors. Furthermore, we would not be able to perform type
 			// evaluation.
-			return nil, nil, fmt.Errorf("subexpressions are only supported on map and list types, %s given", currentType.TypeID())
+			return nil, nil, nil, fmt.Errorf("subexpressions are only supported on map and list types, %s given", currentType.TypeID())
 		}
+		mergedDependencies = append(mergedDependencies, currentDependencies...)
+		return typeResult, chainablePath, mergedDependencies, err
 	}
 }
 
@@ -165,20 +195,15 @@ func (c *dependencyContext) bracketSubExprMapDependencies(
 	keyType schema.Type,
 	leftType schema.Type,
 	leftPath *PathTree,
-) (schema.Type, *PathTree, error) {
+) (schema.Type, *PathTree, []*PathTree, error) {
 	// For maps, we try to compare the type of the map key with the resulting type of the subexpression to
 	// make sure that there are no runtime type failures. The user may need to add type conversion functions
 	// to their expressions to convert an integer to a string, for example.
 	mapType := leftType.(schema.UntypedMap)
 	if keyType.TypeID() != mapType.Keys().TypeID() {
-		return nil, nil, fmt.Errorf("subexpressions resulted in a %s type for a map, %s expected", keyType.TypeID(), mapType.Keys().TypeID())
+		return nil, nil, nil, fmt.Errorf("subexpressions resulted in a %s type for a map, %s expected", keyType.TypeID(), mapType.Keys().TypeID())
 	}
-	pathItem := &PathTree{
-		PathItem: "*",
-		Subtrees: nil,
-	}
-	leftPath.Subtrees = append(leftPath.Subtrees, pathItem)
-	return mapType.Values(), pathItem, nil
+	return mapType.Values(), leftPath, []*PathTree{}, nil
 }
 
 // bracketSubExprListDependencies is used to resolve dependencies when a bracket accessor has a subexpression,
@@ -187,7 +212,7 @@ func (c *dependencyContext) bracketSubExprListDependencies(
 	keyType schema.Type,
 	leftType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, error) {
+) (schema.Type, *PathTree, []*PathTree, error) {
 	// Lists have integer indexes, so we try to make sure that the subexpression is yielding an int or
 	// int-like type. This will have the best chance of not resulting in a runtime error.
 
@@ -195,25 +220,29 @@ func (c *dependencyContext) bracketSubExprListDependencies(
 	switch keyType.TypeID() {
 	case schema.TypeIDInt:
 	default:
-		return nil, nil, fmt.Errorf("subexpressions resulted in a %s type for a list key, integer expected", keyType.TypeID())
+		return nil, nil, nil, fmt.Errorf("subexpressions resulted in a %s type for a list key, integer expected", keyType.TypeID())
 	}
 	pathItem := &PathTree{
 		PathItem: list,
 		Subtrees: nil,
 	}
 	path.Subtrees = append(path.Subtrees, pathItem)
-	return list.Items(), pathItem, nil
+	return list.Items(), path, []*PathTree{}, nil
 }
 
 func (c *dependencyContext) identifierDependencies(
 	node *ast.Identifier,
 	currentType schema.Type,
 	path *PathTree,
-) (schema.Type, *PathTree, error) {
+) (schema.Type, *PathTree, []*PathTree, error) {
 	switch node.IdentifierName {
 	case "$":
 		// This identifier means the root of the expression.
-		return c.rootType, path, nil
+		// Validate that the given path is actually at the root.
+		if path.PathItem != "$" {
+			return nil, nil, nil, fmt.Errorf("root access chained after non-root")
+		}
+		return c.rootType, path, []*PathTree{}, nil
 	default:
 		// This case is the item.item type expression, where the right item is the "identifier" in question.
 		return dependenciesAccessKnownKey(currentType, node.IdentifierName, path)
@@ -222,7 +251,7 @@ func (c *dependencyContext) identifierDependencies(
 
 // dependenciesAccessKnownKey is a helper function that extracts an item in a list, map, or object. This is used when an
 // identifier or a map accessor are encountered.
-func dependenciesAccessKnownKey(currentType schema.Type, key any, path *PathTree) (schema.Type, *PathTree, error) {
+func dependenciesAccessKnownKey(currentType schema.Type, key any, path *PathTree) (schema.Type, *PathTree, []*PathTree, error) {
 	switch currentType.TypeID() {
 	case schema.TypeIDList:
 		// Lists can only have numeric indexes, therefore we need to convert the types to integers. Since internally
@@ -233,20 +262,24 @@ func dependenciesAccessKnownKey(currentType schema.Type, key any, path *PathTree
 		case string:
 			listItem, err = strconv.ParseInt(k, 10, 64)
 			if err != nil {
-				return nil, nil, fmt.Errorf("cannot use non-integer expression identifier %s on list", key)
+				return nil, nil, nil, fmt.Errorf("cannot use non-integer expression identifier %s on list", key)
 			}
 		case int:
 		case int64:
 			listItem = k
 		default:
-			return nil, nil, fmt.Errorf("bug: invalid key type encountered for map key: %T", key)
+			return nil, nil, nil, fmt.Errorf("bug: invalid key type encountered for map key: %T", key)
+		}
+		if path == nil {
+			// Accessing a value that's not based on the main data structure.
+			return currentType.(*schema.ListSchema).ItemsValue, nil, []*PathTree{}, nil
 		}
 		pathItem := &PathTree{
 			PathItem: listItem,
 			Subtrees: nil,
 		}
 		path.Subtrees = append(path.Subtrees, pathItem)
-		return currentType.(*schema.ListSchema).ItemsValue, pathItem, nil
+		return currentType.(*schema.ListSchema).ItemsValue, pathItem, []*PathTree{}, nil
 	case schema.TypeIDMap:
 		// Maps can have various key types, so we need to unserialize the passed key according to its schema and use
 		// it to find the correct key.
@@ -256,10 +289,10 @@ func dependenciesAccessKnownKey(currentType schema.Type, key any, path *PathTree
 		}
 		mapType := currentType.(schema.UntypedMap)
 		if _, err := mapType.Keys().Unserialize(key); err != nil {
-			return nil, nil, fmt.Errorf("cannot unserialize map key type %v (%w)", key, err)
+			return nil, nil, nil, fmt.Errorf("cannot unserialize map key type %v (%w)", key, err)
 		}
 		path.Subtrees = append(path.Subtrees, pathItem)
-		return mapType.Values(), pathItem, nil
+		return mapType.Values(), pathItem, []*PathTree{}, nil
 	case schema.TypeIDObject:
 		fallthrough
 	case schema.TypeIDRef:
@@ -274,29 +307,30 @@ func dependenciesAccessKnownKey(currentType schema.Type, key any, path *PathTree
 		case int:
 			objectItem = fmt.Sprintf("%d", k)
 		default:
-			return nil, nil, fmt.Errorf("bug: invalid key type encountered for object key: %T", key)
+			return nil, nil, nil, fmt.Errorf("bug: invalid key type encountered for object key: %T", key)
 		}
 
 		currentObject := currentType.(schema.Object)
 		properties := currentObject.Properties()
 		property, ok := properties[objectItem]
 		if !ok {
-			return nil, nil, fmt.Errorf("object %s does not have a property named %s", currentObject.ID(), objectItem)
+			return nil, nil, nil, fmt.Errorf("object %s does not have a property named %s", currentObject.ID(), objectItem)
 		}
 		pathItem := &PathTree{
 			PathItem: key,
 			Subtrees: nil,
 		}
+		// It appends itself to the parent path, then returns its own node.
 		path.Subtrees = append(path.Subtrees, pathItem)
-		return property.Type(), pathItem, nil
+		return property.Type(), pathItem, []*PathTree{}, nil
 	case schema.TypeIDAny:
 		pathItem := &PathTree{
 			PathItem: key,
 			Subtrees: nil,
 		}
 		path.Subtrees = append(path.Subtrees, pathItem)
-		return currentType, pathItem, nil
+		return currentType, pathItem, []*PathTree{}, nil
 	default:
-		return nil, nil, fmt.Errorf("cannot evaluate expression identifier %s on data type %s", key, currentType.TypeID())
+		return nil, nil, nil, fmt.Errorf("cannot evaluate expression identifier %s on data type %s", key, currentType.TypeID())
 	}
 }

--- a/expression_dependencies_example_test.go
+++ b/expression_dependencies_example_test.go
@@ -30,12 +30,17 @@ func ExampleExpression_Dependencies() {
 	if err != nil {
 		panic(err)
 	}
-
+	unpackRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     true,
+		IncludeFunctionRootPaths: false,
+		StopAtTerminals:          false,
+		IncludeKeys:              false,
+	}
 	dependencyList, err := expr.Dependencies(
 		myScope,
 		nil,
 		nil,
-		false,
+		unpackRequirements,
 	)
 	if err != nil {
 		panic(err)

--- a/expression_dependencies_example_test.go
+++ b/expression_dependencies_example_test.go
@@ -31,8 +31,8 @@ func ExampleExpression_Dependencies() {
 		panic(err)
 	}
 	unpackRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     true,
-		IncludeFunctionRootPaths: false,
+		ExcludeDataRootPaths:     false,
+		ExcludeFunctionRootPaths: true,
 		StopAtTerminals:          false,
 		IncludeKeys:              false,
 	}

--- a/expression_dependencies_example_test.go
+++ b/expression_dependencies_example_test.go
@@ -35,6 +35,7 @@ func ExampleExpression_Dependencies() {
 		myScope,
 		nil,
 		nil,
+		false,
 	)
 	if err != nil {
 		panic(err)

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -94,7 +94,7 @@ func TestDependencyResolution(t *testing.T) {
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz", path)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo.bar", path)
 			})
-			t.Run("list", func(t *testing.T) {
+			t.Run("list-literal-key", func(t *testing.T) {
 				expr, err := expressions.New("$.int_list[0]")
 				assert.NoError(t, err)
 				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, true)
@@ -110,6 +110,16 @@ func TestDependencyResolution(t *testing.T) {
 					// Without extraneous, the path just refers to the list, since the items of the list have the same schema.
 					assert.Equals(t, pathWithoutExtra[0].String(), "$.int_list")
 				}
+
+			})
+			t.Run("list-subexpr-key", func(t *testing.T) {
+				expr, err := expressions.New("$.int_list[$.simple_int]")
+				assert.NoError(t, err)
+				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, true)
+				assert.NoError(t, err)
+				assert.Equals(t, len(pathWithExtra), 2)
+				assert.SliceContainsExtractor(t, pathStrExtractor, "$.int_list", pathWithExtra)
+				assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", pathWithExtra)
 
 			})
 		})

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -12,11 +12,31 @@ func pathStrExtractor(value expressions.Path) string {
 	return value.String()
 }
 
+var noKeyOrPastTerminalRequirements = expressions.UnpackRequirements{
+	IncludeDataRootPaths:     true,
+	IncludeFunctionRootPaths: false,
+	StopAtTerminals:          true,
+	IncludeKeys:              false,
+}
+var fullDataRequirements = expressions.UnpackRequirements{
+	IncludeDataRootPaths:     true,
+	IncludeFunctionRootPaths: false,
+	StopAtTerminals:          false,
+	IncludeKeys:              true,
+}
+var withFunctionsRequirements = expressions.UnpackRequirements{
+	IncludeDataRootPaths:     true,
+	IncludeFunctionRootPaths: true,
+	StopAtTerminals:          false,
+	IncludeKeys:              true,
+}
+
 func TestDependencyResolution(t *testing.T) {
 	scopes := map[string]schema.Type{
 		"scope": testScope,
 		"any":   schema.NewAnySchema(),
 	}
+
 	// All of these can apply to multiple types, so we'll iterate over the possibilities.
 	for name, schemaType := range scopes {
 		name := name
@@ -25,11 +45,11 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("object", func(t *testing.T) {
 				expr, err := expressions.New("$.foo.bar")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil, true)
+				path, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
 				assert.Equals(t, path[0].String(), "$.foo.bar")
-				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, false)
+				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, noKeyOrPastTerminalRequirements)
 				assert.NoError(t, err)
 				if name == "any" {
 					assert.Equals(t, pathWithoutExtra[0].String(), "$")
@@ -41,7 +61,7 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("map-accessor", func(t *testing.T) {
 				expr, err := expressions.New("$[\"foo\"].bar")
 				assert.NoError(t, err)
-				paths, err := expr.Dependencies(schemaType, nil, nil, true)
+				paths, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				if name == "any" {
 					// There isn't enough info to say this for an any type, but it passes as extraneous
 					assert.NoError(t, err)
@@ -49,14 +69,14 @@ func TestDependencyResolution(t *testing.T) {
 					assert.Equals(t, paths[0].String(), "$.foo.bar")
 				} else {
 					assert.Error(t, err)
-					assert.Contains(t, err.Error(), "scope given")
+					assert.Contains(t, err.Error(), "not supported for object/scope/ref")
 				}
 			})
 
 			t.Run("map", func(t *testing.T) {
 				expr, err := expressions.New("$.faz")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil, true)
+				path, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
 				assert.Equals(t, path[0].String(), "$.faz")
@@ -65,17 +85,15 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("map-subkey", func(t *testing.T) {
 				expr, err := expressions.New(`$.faz["foo"]`)
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil, true)
+				path, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
-				// Note: if includeExtraneous is set to false above, the foo in $.faz["foo"] will be missing because foo is
-				// extraneous due to it being a map key, and when the data type is the `any` type, the path will just be "$"
 				assert.Equals(t, path[0].String(), "$.faz.foo")
 			})
 			t.Run("subexpression-invalid", func(t *testing.T) {
 				expr, err := expressions.New("$.foo[$.faz.foo]")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil, true)
+				path, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				if name == "scope" {
 					assert.Error(t, err)
 				} else {
@@ -83,8 +101,6 @@ func TestDependencyResolution(t *testing.T) {
 					// Order isn't deterministic, so use contains and length validations.
 					assert.Equals(t, len(path), 2)
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo", path)
-					// Note: if includeExtraneous is set to false above, the foo in $.faz.foo will be missing because foo is
-					// extraneous due to it being a map key, and when the data type is the `any` type, the path will just be "$"
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz.foo", path)
 				}
 			})
@@ -92,35 +108,36 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("subexpression", func(t *testing.T) {
 				expr, err := expressions.New("$.faz[$.foo.bar]")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil, true)
+				path, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				// Order isn't deterministic, so use contains and length validations.
 				assert.Equals(t, len(path), 2)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz", path)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo.bar", path)
 			})
+
 			t.Run("list-literal-key", func(t *testing.T) {
 				expr, err := expressions.New("$.int_list[0]")
 				assert.NoError(t, err)
-				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, true)
+				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(pathWithExtra), 1)
 				assert.Equals(t, pathWithExtra[0].String(), "$.int_list.0")
-				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, false)
+				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, noKeyOrPastTerminalRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(pathWithoutExtra), 1)
 				if name == "any" {
 					assert.Equals(t, pathWithoutExtra[0].String(), "$")
 				} else {
-					// Without extraneous, the path just refers to the list, since the items of the list have the same schema.
 					assert.Equals(t, pathWithoutExtra[0].String(), "$.int_list")
 				}
 
 			})
+
 			t.Run("list-subexpr-key", func(t *testing.T) {
 				expr, err := expressions.New("$.int_list[$.simple_int]")
 				assert.NoError(t, err)
-				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, true)
+				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				assert.NoError(t, err)
 				assert.Equals(t, len(pathWithExtra), 2)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.int_list", pathWithExtra)
@@ -134,26 +151,40 @@ func TestDependencyResolution(t *testing.T) {
 func TestLiteralDependencyResolution(t *testing.T) {
 	expr, err := expressions.New(`"test"`)
 	assert.NoError(t, err)
-	path, err := expr.Dependencies(testScope, nil, nil, false)
+	path, err := expr.Dependencies(testScope, nil, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(path), 0) // Does not depend on anything.
+}
+
+func TestImplicitRootDependencyResolution(t *testing.T) {
+	// Tests the root being implicit. $ should be first, even though it's not explicitly specified in the input string.
+	expr, err := expressions.New("foo.bar")
+	assert.NoError(t, err)
+	path, err := expr.Dependencies(testScope, nil, nil, noKeyOrPastTerminalRequirements)
+	assert.NoError(t, err)
+	assert.Equals(t, len(path), 1)
+	assert.Equals(t, path[0].String(), "$.foo.bar")
 }
 
 func TestFunctionDependencyResolution_void(t *testing.T) {
 	voidFunc, err := schema.NewCallableFunction("voidFunc", make([]schema.Type, 0), nil, false, nil, func() {})
 	assert.NoError(t, err)
-
+	funcMap := map[string]schema.Function{"voidFunc": voidFunc}
 	expr, err := expressions.New(`voidFunc()`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, map[string]schema.Function{"voidFunc": voidFunc}, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, withFunctionsRequirements)
+	assert.NoError(t, err)
+	assert.Equals(t, len(dependencyTree), 1)
+	assert.Equals(t, dependencyTree[0].String(), "voidFunc")
 }
 
 func TestFunctionDependencyResolution_error_unknown_func(t *testing.T) {
 	expr, err := expressions.New(`missing()`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, map[string]schema.Function{}, nil, false)
+	_, err = expr.Dependencies(testScope, map[string]schema.Function{}, nil, noKeyOrPastTerminalRequirements)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not find function")
 }
@@ -172,16 +203,21 @@ func TestFunctionDependencyResolution_singleParam(t *testing.T) {
 
 	expr, err := expressions.New(`intIn(5)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, withFunctionsRequirements)
+	assert.NoError(t, err)
+	assert.Equals(t, len(dependencyTree), 1)
+	assert.Equals(t, dependencyTree[0].String(), "intIn")
 
 	expr, err = expressions.New(`intIn($.simple_int)`)
 	assert.NoError(t, err)
-	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, withFunctionsRequirements)
 	assert.NoError(t, err)
-	assert.Equals(t, len(dependencyTree), 1)
-	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
+	assert.Equals(t, len(dependencyTree), 2)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", dependencyTree)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "intIn", dependencyTree)
 }
 
 func TestFunctionDependencyResolution_duplicateDependency(t *testing.T) {
@@ -202,7 +238,7 @@ func TestFunctionDependencyResolution_duplicateDependency(t *testing.T) {
 
 	expr, err := expressions.New(`twoIntIn($.simple_int, $.simple_int)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 1)
 	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
@@ -227,7 +263,7 @@ func TestFunctionDependencyResolution_manyDependencies(t *testing.T) {
 
 	expr, err := expressions.New(`$.faz[test($.simple_int, $.simple_str)]`)
 	assert.NoError(t, err)
-	dependencyPaths, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyPaths, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyPaths), 3)
 	assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz", dependencyPaths)
@@ -253,7 +289,7 @@ func TestFunctionDependencyResolution_multiParam(t *testing.T) {
 
 	expr, err := expressions.New(`test(5, $.simple_int, $.simple_str)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 2)
 	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", dependencyTree)
@@ -274,10 +310,11 @@ func TestFunctionDependencyResolution_compoundFunctions(t *testing.T) {
 
 	expr, err := expressions.New(`intInOut(intInOut($.simple_int))`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, withFunctionsRequirements)
 	assert.NoError(t, err)
-	assert.Equals(t, len(dependencyTree), 1)
-	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
+	assert.Equals(t, len(dependencyTree), 2)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", dependencyTree)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "intInOut", dependencyTree)
 }
 
 func TestFunctionDependencyResolution_error_wrongType(t *testing.T) {
@@ -294,7 +331,7 @@ func TestFunctionDependencyResolution_error_wrongType(t *testing.T) {
 
 	expr, err := expressions.New(`intIn("wrongType")`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil, false)
+	_, err = expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.Error(t, err)
 	// Validate that it detected a type problem
 	assert.Contains(t, err.Error(), "error while validating arg/param type compatibility")
@@ -316,7 +353,7 @@ func TestFunctionDependencyResolution_error_wrongArgCount(t *testing.T) {
 
 	expr, err := expressions.New(`intIn(5, 5)`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil, false)
+	_, err = expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.Error(t, err)
 	// Validate that it detected a type problem
 	assert.Contains(t, err.Error(), "Expected 1 args, got 2 args")
@@ -363,25 +400,25 @@ func TestFunctionDependencyResolution_dynamicTyping(t *testing.T) {
 	// Test identity returning int when given int
 	expr, err := expressions.New(`intIn(identity(1))`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 	// Test identity returning str when given str
 	expr, err = expressions.New(`strIn(identity("test"))`)
 	assert.NoError(t, err)
-	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, false)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 	// Test type mismatch
 	expr, err = expressions.New(`strIn(identity(1))`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil, false)
+	_, err = expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported data type")
 	// Second test type mismatch
 	expr, err = expressions.New(`intIn(identity("test"))`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil, false)
+	_, err = expr.Dependencies(testScope, funcMap, nil, noKeyOrPastTerminalRequirements)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported data type")
 }

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -13,20 +13,20 @@ func pathStrExtractor(value expressions.Path) string {
 }
 
 var noKeyOrPastTerminalRequirements = expressions.UnpackRequirements{
-	IncludeDataRootPaths:     true,
-	IncludeFunctionRootPaths: false,
+	ExcludeDataRootPaths:     false,
+	ExcludeFunctionRootPaths: true,
 	StopAtTerminals:          true,
 	IncludeKeys:              false,
 }
 var fullDataRequirements = expressions.UnpackRequirements{
-	IncludeDataRootPaths:     true,
-	IncludeFunctionRootPaths: false,
+	ExcludeDataRootPaths:     false,
+	ExcludeFunctionRootPaths: true,
 	StopAtTerminals:          false,
 	IncludeKeys:              true,
 }
 var withFunctionsRequirements = expressions.UnpackRequirements{
-	IncludeDataRootPaths:     true,
-	IncludeFunctionRootPaths: true,
+	ExcludeDataRootPaths:     false,
+	ExcludeFunctionRootPaths: false,
 	StopAtTerminals:          false,
 	IncludeKeys:              true,
 }
@@ -63,7 +63,8 @@ func TestDependencyResolution(t *testing.T) {
 				assert.NoError(t, err)
 				paths, err := expr.Dependencies(schemaType, nil, nil, fullDataRequirements)
 				if name == "any" {
-					// There isn't enough info to say this for an any type, but it passes as extraneous
+					// There isn't enough info to say this for an any type, but we set in the requirements
+					// to include past-terminal (any) data types.
 					assert.NoError(t, err)
 					assert.Equals(t, len(paths), 1)
 					assert.Equals(t, paths[0].String(), "$.foo.bar")

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -8,13 +8,14 @@ import (
 	"go.flow.arcalot.io/pluginsdk/schema"
 )
 
+var pathStrExtractor = func(value expressions.Path) string {
+	return value.String()
+}
+
 func TestDependencyResolution(t *testing.T) {
 	scopes := map[string]schema.Type{
 		"scope": testScope,
 		"any":   schema.NewAnySchema(),
-	}
-	pathStrExtractor := func(value expressions.Path) string {
-		return value.String()
 	}
 	// All of these can apply to multiple types, so we'll iterate over the possibilities.
 	for name, schemaType := range scopes {
@@ -24,25 +25,32 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("object", func(t *testing.T) {
 				expr, err := expressions.New("$.foo.bar")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
 				assert.Equals(t, path[0].String(), "$.foo.bar")
+				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, false)
+				if name == "any" {
+					assert.Equals(t, pathWithoutExtra[0].String(), "$")
+				} else {
+					assert.Equals(t, pathWithoutExtra[0].String(), "$.foo.bar")
+				}
 			})
 
 			t.Run("map-accessor", func(t *testing.T) {
 				expr, err := expressions.New("$[\"foo\"].bar")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
+				// We only know the path with the scope. Not with the 'any' type.
 				assert.Equals(t, path[0].String(), "$.foo.bar")
 			})
 
 			t.Run("map", func(t *testing.T) {
 				expr, err := expressions.New("$.faz")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
 				assert.Equals(t, path[0].String(), "$.faz")
@@ -51,15 +59,17 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("map-subkey", func(t *testing.T) {
 				expr, err := expressions.New("$.faz.foo")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
+				// Note: if includeExtraneous is set to false, the foo in $.faz.foo will be missing because foo is
+				// extraneous due to it being a map key, and when the data type is the `any` type, it will just be "$"
 				assert.Equals(t, path[0].String(), "$.faz.foo")
 			})
 			t.Run("subexpression-invalid", func(t *testing.T) {
 				expr, err := expressions.New("$.foo[$.faz.foo]")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				if name == "scope" {
 					assert.Error(t, err)
 				} else {
@@ -67,6 +77,8 @@ func TestDependencyResolution(t *testing.T) {
 					// Order isn't deterministic, so use contains and length validations.
 					assert.Equals(t, len(path), 2)
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo", path)
+					// Note: if includeExtraneous is set to false, the foo in $.faz.foo will be missing because foo is
+					// extraneous due to it being a map key, and when the data type is the `any` type, it will just be "$"
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz.foo", path)
 				}
 			})
@@ -74,12 +86,30 @@ func TestDependencyResolution(t *testing.T) {
 			t.Run("subexpression", func(t *testing.T) {
 				expr, err := expressions.New("$.faz[$.foo.bar]")
 				assert.NoError(t, err)
-				path, err := expr.Dependencies(schemaType, nil, nil)
+				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				// Order isn't deterministic, so use contains and length validations.
 				assert.Equals(t, len(path), 2)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz", path)
 				assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo.bar", path)
+			})
+			t.Run("list", func(t *testing.T) {
+				expr, err := expressions.New("$.int_list[0]")
+				assert.NoError(t, err)
+				pathWithExtra, err := expr.Dependencies(schemaType, nil, nil, true)
+				assert.NoError(t, err)
+				assert.Equals(t, len(pathWithExtra), 1)
+				assert.Equals(t, pathWithExtra[0].String(), "$.int_list.0")
+				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, false)
+				assert.NoError(t, err)
+				assert.Equals(t, len(pathWithoutExtra), 1)
+				if name == "any" {
+					assert.Equals(t, pathWithoutExtra[0].String(), "$")
+				} else {
+					// Without extraneous, the path just refers to the list, since the items of the list have the same schema.
+					assert.Equals(t, pathWithoutExtra[0].String(), "$.int_list")
+				}
+
 			})
 		})
 	}
@@ -88,7 +118,7 @@ func TestDependencyResolution(t *testing.T) {
 func TestLiteralDependencyResolution(t *testing.T) {
 	expr, err := expressions.New(`"test"`)
 	assert.NoError(t, err)
-	path, err := expr.Dependencies(testScope, nil, nil)
+	path, err := expr.Dependencies(testScope, nil, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(path), 0) // Does not depend on anything.
 }
@@ -99,7 +129,7 @@ func TestFunctionDependencyResolution_void(t *testing.T) {
 
 	expr, err := expressions.New(`voidFunc()`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, map[string]schema.Function{"voidFunc": voidFunc}, nil)
+	dependencyTree, err := expr.Dependencies(testScope, map[string]schema.Function{"voidFunc": voidFunc}, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 }
@@ -107,7 +137,7 @@ func TestFunctionDependencyResolution_void(t *testing.T) {
 func TestFunctionDependencyResolution_error_unknown_func(t *testing.T) {
 	expr, err := expressions.New(`missing()`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, map[string]schema.Function{}, nil)
+	_, err = expr.Dependencies(testScope, map[string]schema.Function{}, nil, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "could not find function")
 }
@@ -126,13 +156,13 @@ func TestFunctionDependencyResolution_singleParam(t *testing.T) {
 
 	expr, err := expressions.New(`intIn(5)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 
 	expr, err = expressions.New(`intIn($.simple_int)`)
 	assert.NoError(t, err)
-	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 1)
 	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
@@ -156,10 +186,37 @@ func TestFunctionDependencyResolution_duplicateDependency(t *testing.T) {
 
 	expr, err := expressions.New(`twoIntIn($.simple_int, $.simple_int)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 1)
 	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
+}
+
+func TestFunctionDependencyResolution_manyDependencies(t *testing.T) {
+	// This tests two dependencies from the function, and one from the map access.
+	// This is necessary because we need to validate that the dependencies are merged correctly.
+	intInFunc, err := schema.NewCallableFunction(
+		"test",
+		[]schema.Type{
+			schema.NewIntSchema(nil, nil, nil),
+			schema.NewStringSchema(nil, nil, nil),
+		},
+		schema.NewStringSchema(nil, nil, nil),
+		false,
+		nil,
+		func(a int64, b string) string { return b },
+	)
+	assert.NoError(t, err)
+	funcMap := map[string]schema.Function{"test": intInFunc}
+
+	expr, err := expressions.New(`$.faz[test($.simple_int, $.simple_str)]`)
+	assert.NoError(t, err)
+	dependencyPaths, err := expr.Dependencies(testScope, funcMap, nil, false)
+	assert.NoError(t, err)
+	assert.Equals(t, len(dependencyPaths), 3)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz", dependencyPaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", dependencyPaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_str", dependencyPaths)
 }
 
 func TestFunctionDependencyResolution_multiParam(t *testing.T) {
@@ -180,11 +237,11 @@ func TestFunctionDependencyResolution_multiParam(t *testing.T) {
 
 	expr, err := expressions.New(`test(5, $.simple_int, $.simple_str)`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 2)
-	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
-	assert.Equals(t, dependencyTree[1].String(), "$.simple_str")
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_int", dependencyTree)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.simple_str", dependencyTree)
 }
 
 func TestFunctionDependencyResolution_compoundFunctions(t *testing.T) {
@@ -201,7 +258,7 @@ func TestFunctionDependencyResolution_compoundFunctions(t *testing.T) {
 
 	expr, err := expressions.New(`intInOut(intInOut($.simple_int))`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 1)
 	assert.Equals(t, dependencyTree[0].String(), "$.simple_int")
@@ -221,7 +278,7 @@ func TestFunctionDependencyResolution_error_wrongType(t *testing.T) {
 
 	expr, err := expressions.New(`intIn("wrongType")`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil)
+	_, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.Error(t, err)
 	// Validate that it detected a type problem
 	assert.Contains(t, err.Error(), "error while validating arg/param type compatibility")
@@ -243,7 +300,7 @@ func TestFunctionDependencyResolution_error_wrongArgCount(t *testing.T) {
 
 	expr, err := expressions.New(`intIn(5, 5)`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil)
+	_, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.Error(t, err)
 	// Validate that it detected a type problem
 	assert.Contains(t, err.Error(), "Expected 1 args, got 2 args")
@@ -290,25 +347,25 @@ func TestFunctionDependencyResolution_dynamicTyping(t *testing.T) {
 	// Test identity returning int when given int
 	expr, err := expressions.New(`intIn(identity(1))`)
 	assert.NoError(t, err)
-	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err := expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 	// Test identity returning str when given str
 	expr, err = expressions.New(`strIn(identity("test"))`)
 	assert.NoError(t, err)
-	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil)
+	dependencyTree, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.NoError(t, err)
 	assert.Equals(t, len(dependencyTree), 0)
 	// Test type mismatch
 	expr, err = expressions.New(`strIn(identity(1))`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil)
+	_, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported data type")
 	// Second test type mismatch
 	expr, err = expressions.New(`intIn(identity("test"))`)
 	assert.NoError(t, err)
-	_, err = expr.Dependencies(testScope, funcMap, nil)
+	_, err = expr.Dependencies(testScope, funcMap, nil, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported data type")
 }

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -8,7 +8,7 @@ import (
 	"go.flow.arcalot.io/pluginsdk/schema"
 )
 
-var pathStrExtractor = func(value expressions.Path) string {
+func pathStrExtractor(value expressions.Path) string {
 	return value.String()
 }
 
@@ -68,8 +68,8 @@ func TestDependencyResolution(t *testing.T) {
 				path, err := expr.Dependencies(schemaType, nil, nil, true)
 				assert.NoError(t, err)
 				assert.Equals(t, len(path), 1)
-				// Note: if includeExtraneous is set to false, the foo in $.faz["foo"] will be missing because foo is
-				// extraneous due to it being a map key, and when the data type is the `any` type, it will just be "$"
+				// Note: if includeExtraneous is set to false above, the foo in $.faz["foo"] will be missing because foo is
+				// extraneous due to it being a map key, and when the data type is the `any` type, the path will just be "$"
 				assert.Equals(t, path[0].String(), "$.faz.foo")
 			})
 			t.Run("subexpression-invalid", func(t *testing.T) {
@@ -83,8 +83,8 @@ func TestDependencyResolution(t *testing.T) {
 					// Order isn't deterministic, so use contains and length validations.
 					assert.Equals(t, len(path), 2)
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.foo", path)
-					// Note: if includeExtraneous is set to false, the foo in $.faz.foo will be missing because foo is
-					// extraneous due to it being a map key, and when the data type is the `any` type, it will just be "$"
+					// Note: if includeExtraneous is set to false above, the foo in $.faz.foo will be missing because foo is
+					// extraneous due to it being a map key, and when the data type is the `any` type, the path will just be "$"
 					assert.SliceContainsExtractor(t, pathStrExtractor, "$.faz.foo", path)
 				}
 			})
@@ -185,7 +185,7 @@ func TestFunctionDependencyResolution_singleParam(t *testing.T) {
 }
 
 func TestFunctionDependencyResolution_duplicateDependency(t *testing.T) {
-	// Tests that is doesn't include the same dependency twice.
+	// Tests that it doesn't include the same dependency twice.
 	intInFunc, err := schema.NewCallableFunction(
 		"twoIntIn",
 		[]schema.Type{

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -8,10 +8,6 @@ import (
 	"go.flow.arcalot.io/pluginsdk/schema"
 )
 
-func pathStrExtractor(value expressions.Path) string {
-	return value.String()
-}
-
 var noKeyOrPastTerminalRequirements = expressions.UnpackRequirements{
 	ExcludeDataRootPaths:     false,
 	ExcludeFunctionRootPaths: true,

--- a/expression_dependencies_test.go
+++ b/expression_dependencies_test.go
@@ -30,6 +30,7 @@ func TestDependencyResolution(t *testing.T) {
 				assert.Equals(t, len(path), 1)
 				assert.Equals(t, path[0].String(), "$.foo.bar")
 				pathWithoutExtra, err := expr.Dependencies(schemaType, nil, nil, false)
+				assert.NoError(t, err)
 				if name == "any" {
 					assert.Equals(t, pathWithoutExtra[0].String(), "$")
 				} else {

--- a/expression_type_test.go
+++ b/expression_type_test.go
@@ -19,11 +19,12 @@ func TestTypeEvaluation(t *testing.T) {
 	})
 
 	t.Run("map-accessor", func(t *testing.T) {
-		expr, err := expressions.New("$[\"foo\"].bar")
+		expr, err := expressions.New(`$.faz["abc"]`)
 		assert.NoError(t, err)
 		resultType, err := expr.Type(testScope, nil, nil)
 		assert.NoError(t, err)
-		assert.Equals(t, resultType.TypeID(), schema.TypeIDString)
+		// The value type of the map is object.
+		assert.Equals(t, resultType.TypeID(), schema.TypeIDObject)
 	})
 
 	t.Run("map", func(t *testing.T) {
@@ -32,14 +33,6 @@ func TestTypeEvaluation(t *testing.T) {
 		resultType, err := expr.Type(testScope, nil, nil)
 		assert.NoError(t, err)
 		assert.Equals(t, resultType.TypeID(), schema.TypeIDMap)
-	})
-
-	t.Run("map-subkey", func(t *testing.T) {
-		expr, err := expressions.New("$.faz.foo")
-		assert.NoError(t, err)
-		resultType, err := expr.Type(testScope, nil, nil)
-		assert.NoError(t, err)
-		assert.Equals(t, resultType.TypeID(), schema.TypeIDObject)
 	})
 
 	t.Run("subexpression-invalid", func(t *testing.T) {
@@ -56,6 +49,30 @@ func TestTypeEvaluation(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equals(t, resultType.TypeID(), schema.TypeIDObject)
 
+	})
+
+	t.Run("list-value", func(t *testing.T) {
+		expr, err := expressions.New("$.int_list")
+		assert.NoError(t, err)
+		resultType, err := expr.Type(testScope, nil, nil)
+		assert.NoError(t, err)
+		assert.Equals(t, resultType.TypeID(), schema.TypeIDList)
+	})
+
+	t.Run("list-item", func(t *testing.T) {
+		expr, err := expressions.New("$.int_list[0]")
+		assert.NoError(t, err)
+		resultType, err := expr.Type(testScope, nil, nil)
+		assert.NoError(t, err)
+		assert.Equals(t, resultType.TypeID(), schema.TypeIDInt)
+	})
+
+	t.Run("any-schema", func(t *testing.T) {
+		expr, err := expressions.New("$.simple_any.a.b")
+		assert.NoError(t, err)
+		resultType, err := expr.Type(testScope, nil, nil)
+		assert.NoError(t, err)
+		assert.Equals(t, resultType.TypeID(), schema.TypeIDAny)
 	})
 }
 

--- a/internal/ast/grammar_test.go
+++ b/internal/ast/grammar_test.go
@@ -560,3 +560,12 @@ func TestExpressionInvalidIdentifier(t *testing.T) {
 	_, err = p.ParseExpression()
 	assert.Error(t, err)
 }
+
+func TestExpressionErrorChainLiteral(t *testing.T) {
+	expression := `"a".a`
+	p, err := InitParser(expression, t.Name())
+	assert.NoError(t, err)
+	_, err = p.ParseExpression()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Expected end of expression")
+}

--- a/path.go
+++ b/path.go
@@ -68,15 +68,15 @@ func (p PathTree) Unpack(requirements UnpackRequirements) []Path {
 			result = append(result, currentPathNodes)
 		}
 	}
-	if len(result) == 0 { // Happens when there are only extraneous subtrees
+	if len(result) == 0 { // Happens when the fields are excluded based on the current requirements
 		result = append(result, []any{p.PathItem})
 	}
 	return result
 }
 
 type UnpackRequirements struct {
-	IncludeDataRootPaths     bool // Include paths that start at data root
-	IncludeFunctionRootPaths bool // Include paths that start at a function
+	ExcludeDataRootPaths     bool // Exclude paths that start at data root
+	ExcludeFunctionRootPaths bool // Exclude paths that start at a function
 	StopAtTerminals          bool // Whether to stop at terminals (any types are terminals).
 	IncludeKeys              bool // Whether to include the keys in the path. // Example, the 0 in `$ -> list -> 0 -> a`
 }
@@ -84,15 +84,15 @@ type UnpackRequirements struct {
 func (r *UnpackRequirements) shouldStop(nodeType PathNodeType) bool {
 	switch nodeType {
 	case DataRootNode:
-		return !r.IncludeDataRootPaths
+		return r.ExcludeDataRootPaths
 	case FunctionNode:
-		return !r.IncludeFunctionRootPaths
+		return r.ExcludeFunctionRootPaths
 	case PastTerminalNode:
 		return r.StopAtTerminals
 	case AccessNode, KeyNode:
-		fallthrough
-	default:
 		return false
+	default:
+		panic(fmt.Errorf("node type %q missing in shouldStop in path", nodeType))
 	}
 }
 

--- a/path.go
+++ b/path.go
@@ -20,22 +20,35 @@ func (p Path) String() string {
 
 // PathTree holds multiple paths in a branching fashion.
 type PathTree struct {
+	// The value at the part of the tree
 	PathItem any
-	Subtrees []*PathTree
+	// Extra values that do not contribute to the validated path, like within `any` values, or map indexes
+	Extraneous []any
+	Subtrees   []*PathTree
 }
 
 // Unpack unpacks the path tree into a list of paths.
-func (p PathTree) Unpack() []Path {
+func (p PathTree) Unpack(includeExtraneous bool) []Path {
 	if len(p.Subtrees) > 0 {
 		var result []Path
 		for _, subtree := range p.Subtrees {
-			for _, subtreeResult := range subtree.Unpack() {
-				currentPathNodes := append([]any{p.PathItem}, subtreeResult...)
+			for _, subtreeResult := range subtree.Unpack(includeExtraneous) {
+				// First, this path item
+				currentPathNodes := []any{p.PathItem}
+				// Second, if requested, the extraneous values
+				if includeExtraneous {
+					currentPathNodes = append(currentPathNodes, p.Extraneous...)
+				}
+				// Lastly add the sub-trees
+				currentPathNodes = append(currentPathNodes, subtreeResult...)
 				result = append(result, currentPathNodes)
 			}
 		}
 		return result
 	}
-
-	return []Path{{p.PathItem}}
+	result := []any{p.PathItem}
+	if includeExtraneous {
+		result = append(result, p.Extraneous...)
+	}
+	return []Path{result}
 }

--- a/path.go
+++ b/path.go
@@ -30,7 +30,8 @@ func (p PathTree) Unpack() []Path {
 		var result []Path
 		for _, subtree := range p.Subtrees {
 			for _, subtreeResult := range subtree.Unpack() {
-				result = append(result, append([]any{p.PathItem}, subtreeResult...))
+				currentPathNodes := append([]any{p.PathItem}, subtreeResult...)
+				result = append(result, currentPathNodes)
 			}
 		}
 		return result

--- a/path.go
+++ b/path.go
@@ -51,7 +51,7 @@ type PathTree struct {
 
 // Unpack unpacks the path tree into a list of paths.
 func (p PathTree) Unpack(requirements UnpackRequirements) []Path {
-	if requirements.shouldStop(p.NodeType) || len(p.Subtrees) == 0 && requirements.shouldSkip(p.NodeType) {
+	if requirements.shouldStop(p.NodeType) {
 		return []Path{}
 	}
 	var result []Path
@@ -68,9 +68,15 @@ func (p PathTree) Unpack(requirements UnpackRequirements) []Path {
 			result = append(result, currentPathNodes)
 		}
 	}
-	if len(result) == 0 { // Happens when the fields are excluded based on the current requirements
-		result = append(result, []any{p.PathItem})
+
+	// An empty result happens when either there are zero subtrees, or the
+	// subtrees are excluded based on the current requirements.
+	// Return the current path if the current path node should be an included
+	// leaf node. Skipped nodes should not.
+	if len(result) == 0 && !requirements.shouldSkip(p.NodeType) {
+		return []Path{[]any{p.PathItem}}
 	}
+
 	return result
 }
 

--- a/path_test.go
+++ b/path_test.go
@@ -7,35 +7,95 @@ import (
 	"go.flow.arcalot.io/expressions"
 )
 
-func TestPathTree_Unpack(t *testing.T) {
+func TestPathTree_UnpackDataPaths(t *testing.T) {
 	pathTree := expressions.PathTree{
 		PathItem: "foo",
+		NodeType: expressions.DataRootNode,
 		Subtrees: []*expressions.PathTree{
 			{
 				"bar",
-				false,
+				expressions.AccessNode,
 				nil,
 			},
 			{
 				"baz",
-				false,
+				expressions.AccessNode,
 				[]*expressions.PathTree{
 					{
 						0,
-						true,
-						nil,
+						expressions.KeyNode,
+						[]*expressions.PathTree{
+							{
+								"a",
+								expressions.AccessNode,
+								nil,
+							},
+						},
 					},
 				},
 			},
 		},
 	}
-	paths := pathTree.Unpack(false)
-	pathsWithExtranous := pathTree.Unpack(true)
+	noKeyRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     true,
+		IncludeFunctionRootPaths: false,
+		StopAtTerminals:          false,
+		IncludeKeys:              false,
+	}
+	withKeyRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     true,
+		IncludeFunctionRootPaths: false,
+		StopAtTerminals:          false,
+		IncludeKeys:              true,
+	}
+	noDataRootRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     false,
+		IncludeFunctionRootPaths: false,
+		StopAtTerminals:          false,
+		IncludeKeys:              true,
+	}
+	pathsWithoutKeys := pathTree.Unpack(noKeyRequirements)
+	pathsWithKeys := pathTree.Unpack(withKeyRequirements)
+	pathsWithoutDataRoot := pathTree.Unpack(noDataRootRequirements)
 
-	assert.Equals(t, len(paths), 2)
-	assert.Equals(t, len(pathsWithExtranous), 2)
-	assert.Equals(t, paths[0].String(), "foo.bar")
-	assert.Equals(t, pathsWithExtranous[0].String(), "foo.bar")
-	assert.Equals(t, paths[1].String(), "foo.baz")
-	assert.Equals(t, pathsWithExtranous[1].String(), "foo.baz.0")
+	assert.Equals(t, len(pathsWithoutKeys), 2)
+	assert.Equals(t, len(pathsWithKeys), 2)
+	assert.Equals(t, len(pathsWithoutDataRoot), 0)
+	assert.Equals(t, pathsWithoutKeys[0].String(), "foo.bar")
+	assert.Equals(t, pathsWithKeys[0].String(), "foo.bar")
+	assert.Equals(t, pathsWithoutKeys[1].String(), "foo.baz.a")
+	assert.Equals(t, pathsWithKeys[1].String(), "foo.baz.0.a")
+}
+
+func TestPathTree_UnpackFuncPaths(t *testing.T) {
+	pathTree := expressions.PathTree{
+		PathItem: "someFunction",
+		NodeType: expressions.FunctionNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				"foo",
+				expressions.AccessNode,
+				nil,
+			},
+		},
+	}
+
+	noDataRootRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     false,
+		IncludeFunctionRootPaths: true,
+		StopAtTerminals:          false,
+		IncludeKeys:              true,
+	}
+	noFunctionsRootRequirements := expressions.UnpackRequirements{
+		IncludeDataRootPaths:     true,
+		IncludeFunctionRootPaths: false,
+		StopAtTerminals:          false,
+		IncludeKeys:              true,
+	}
+
+	pathsWithoutDataRoot := pathTree.Unpack(noDataRootRequirements)
+	pathsWithoutFunctionsRoot := pathTree.Unpack(noFunctionsRootRequirements)
+	assert.Equals(t, len(pathsWithoutFunctionsRoot), 0)
+	assert.Equals(t, len(pathsWithoutDataRoot), 1)
+	assert.Equals(t, pathsWithoutDataRoot[0].String(), "someFunction.foo")
 }

--- a/path_test.go
+++ b/path_test.go
@@ -9,18 +9,23 @@ import (
 
 func TestPathTree_Unpack(t *testing.T) {
 	pathTree := expressions.PathTree{
-		PathItem:   "foo",
-		Extraneous: []any{"a"},
+		PathItem: "foo",
 		Subtrees: []*expressions.PathTree{
 			{
 				"bar",
-				[]any{},
+				false,
 				nil,
 			},
 			{
 				"baz",
-				[]any{0},
-				nil,
+				false,
+				[]*expressions.PathTree{
+					{
+						0,
+						true,
+						nil,
+					},
+				},
 			},
 		},
 	}
@@ -30,7 +35,7 @@ func TestPathTree_Unpack(t *testing.T) {
 	assert.Equals(t, len(paths), 2)
 	assert.Equals(t, len(pathsWithExtranous), 2)
 	assert.Equals(t, paths[0].String(), "foo.bar")
-	assert.Equals(t, pathsWithExtranous[0].String(), "foo.a.bar")
+	assert.Equals(t, pathsWithExtranous[0].String(), "foo.bar")
 	assert.Equals(t, paths[1].String(), "foo.baz")
-	assert.Equals(t, pathsWithExtranous[1].String(), "foo.a.baz.0")
+	assert.Equals(t, pathsWithExtranous[1].String(), "foo.baz.0")
 }

--- a/path_test.go
+++ b/path_test.go
@@ -7,6 +7,10 @@ import (
 	"go.flow.arcalot.io/expressions"
 )
 
+func pathStrExtractor(value expressions.Path) string {
+	return value.String()
+}
+
 func TestPathTree_UnpackDataPaths(t *testing.T) {
 	pathTree := expressions.PathTree{
 		PathItem: "foo",
@@ -91,4 +95,249 @@ func TestPathTree_UnpackFuncPaths(t *testing.T) {
 	assert.Equals(t, len(pathsWithoutFunctionsRoot), 0)
 	assert.Equals(t, len(pathsWithoutDataRoot), 1)
 	assert.Equals(t, pathsWithoutDataRoot[0].String(), "someFunction.foo")
+}
+
+func TestPathTree_UnpackNoSubtrees(t *testing.T) {
+	funcPathTree := expressions.PathTree{
+		PathItem: "someFunction",
+		NodeType: expressions.FunctionNode,
+		Subtrees: []*expressions.PathTree{},
+	}
+	rootPathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{},
+	}
+	nonRootPathTree := expressions.PathTree{
+		PathItem: "a",
+		NodeType: expressions.AccessNode,
+		Subtrees: []*expressions.PathTree{},
+	}
+
+	defaultRequirements := expressions.UnpackRequirements{}
+
+	funcTreePaths := funcPathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(funcTreePaths), 1)
+	assert.Equals(t, funcTreePaths[0].String(), "someFunction")
+	rootTreePaths := rootPathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(rootTreePaths), 1)
+	assert.Equals(t, rootTreePaths[0].String(), "$")
+	nonRootTreePaths := nonRootPathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(nonRootTreePaths), 1)
+	assert.Equals(t, nonRootTreePaths[0].String(), "a")
+}
+
+func TestPathTree_UnpackLeafKeys(t *testing.T) {
+	// This test keeps it simple, with a key in the end (leaf), so we ensure that it's
+	// kept only when IncludeTrees is true.
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				PathItem: "a",
+				NodeType: expressions.KeyNode,
+				Subtrees: nil,
+			},
+		},
+	}
+
+	defaultRequirements := expressions.UnpackRequirements{}
+	withKeysRequirements := expressions.UnpackRequirements{
+		IncludeKeys: true,
+	}
+
+	noKeyTreePaths := pathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(noKeyTreePaths), 1)
+	assert.Equals(t, noKeyTreePaths[0].String(), "$")
+	withKeyTreePaths := pathTree.Unpack(withKeysRequirements)
+	assert.Equals(t, len(withKeyTreePaths), 1)
+	assert.Equals(t, withKeyTreePaths[0].String(), "$.a")
+}
+
+func TestPathTree_UnpackMiddleKeys(t *testing.T) {
+	// This tests when a key in the middle level of the tree, with a non-key leaf after it.
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				PathItem: "a",
+				NodeType: expressions.KeyNode,
+				Subtrees: []*expressions.PathTree{
+					{
+						PathItem: "b",
+						NodeType: expressions.AccessNode,
+						Subtrees: nil,
+					},
+				},
+			},
+		},
+	}
+
+	defaultRequirements := expressions.UnpackRequirements{}
+	withKeysRequirements := expressions.UnpackRequirements{
+		IncludeKeys: true,
+	}
+
+	noKeyTreePaths := pathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(noKeyTreePaths), 1)
+	assert.Equals(t, noKeyTreePaths[0].String(), "$.b")
+	withKeyTreePaths := pathTree.Unpack(withKeysRequirements)
+	assert.Equals(t, len(withKeyTreePaths), 1)
+	assert.Equals(t, withKeyTreePaths[0].String(), "$.a.b")
+}
+
+func TestPathTree_UnpackL2Excluded(t *testing.T) {
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				PathItem: "a",
+				NodeType: expressions.PastTerminalNode,
+				Subtrees: nil,
+			},
+			{
+				PathItem: "b",
+				NodeType: expressions.PastTerminalNode,
+				Subtrees: nil,
+			},
+		},
+	}
+	noPastTerminalRequirements := expressions.UnpackRequirements{
+		StopAtTerminals: true,
+	}
+
+	treePaths := pathTree.Unpack(noPastTerminalRequirements)
+	assert.Equals(t, len(treePaths), 1)
+	assert.Equals(t, treePaths[0].String(), "$")
+}
+
+func TestPathTree_UnpackL3Excluded(t *testing.T) {
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				PathItem: "l2-a",
+				NodeType: expressions.AccessNode,
+				Subtrees: []*expressions.PathTree{
+					{
+						PathItem: "l3",
+						NodeType: expressions.PastTerminalNode,
+						Subtrees: nil,
+					},
+				},
+			},
+			{
+				PathItem: "l2-b",
+				NodeType: expressions.AccessNode,
+				Subtrees: []*expressions.PathTree{
+					{
+						PathItem: "l3",
+						NodeType: expressions.PastTerminalNode,
+						Subtrees: nil,
+					},
+				},
+			},
+		},
+	}
+	noPastTerminalRequirements := expressions.UnpackRequirements{
+		StopAtTerminals: true,
+	}
+
+	treePaths := pathTree.Unpack(noPastTerminalRequirements)
+	assert.Equals(t, len(treePaths), 2)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-a", treePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-b", treePaths)
+}
+
+func TestPathTree_UnpackManySubtrees(t *testing.T) {
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: expressions.DataRootNode,
+		Subtrees: []*expressions.PathTree{
+			{
+				PathItem: "l2-a",
+				NodeType: expressions.AccessNode,
+				Subtrees: []*expressions.PathTree{
+					{
+						PathItem: "l3-a",
+						NodeType: expressions.AccessNode,
+						Subtrees: nil,
+					},
+					{
+						PathItem: "l3-b",
+						NodeType: expressions.AccessNode,
+						Subtrees: nil,
+					},
+				},
+			},
+			{
+				PathItem: "l2-b",
+				NodeType: expressions.AccessNode,
+				Subtrees: []*expressions.PathTree{
+					{
+						PathItem: "l3-a",
+						NodeType: expressions.AccessNode,
+						Subtrees: []*expressions.PathTree{
+							{
+								PathItem: "l4-a",
+								NodeType: expressions.AccessNode,
+								Subtrees: nil,
+							},
+							{
+								PathItem: "l4-b",
+								NodeType: expressions.AccessNode,
+								Subtrees: []*expressions.PathTree{
+									{
+										PathItem: "l5-a",
+										NodeType: expressions.AccessNode,
+										Subtrees: nil,
+									},
+									{
+										PathItem: "l5-b",
+										NodeType: expressions.AccessNode,
+										Subtrees: nil,
+									},
+								},
+							},
+						},
+					},
+					{
+						PathItem: "l3-b",
+						NodeType: expressions.AccessNode,
+						Subtrees: nil,
+					},
+				},
+			},
+		},
+	}
+	defaultRequirements := expressions.UnpackRequirements{}
+
+	funcTreePaths := pathTree.Unpack(defaultRequirements)
+	assert.Equals(t, len(funcTreePaths), 6)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-a.l3-a", funcTreePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-a.l3-b", funcTreePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-b.l3-a.l4-a", funcTreePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-b.l3-a.l4-b.l5-a", funcTreePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-b.l3-a.l4-b.l5-b", funcTreePaths)
+	assert.SliceContainsExtractor(t, pathStrExtractor, "$.l2-b.l3-b", funcTreePaths)
+}
+
+func TestPathTree_ErrorUnpackInvalidType(t *testing.T) {
+	// The NodeType is an alias of String, so submit an invalid one to ensure
+	// that it panics.
+	pathTree := expressions.PathTree{
+		PathItem: "$",
+		NodeType: "abc-invalid",
+		Subtrees: nil,
+	}
+
+	defaultRequirements := expressions.UnpackRequirements{}
+
+	assert.Panics(t, func() {
+		_ = pathTree.Unpack(defaultRequirements)
+	})
 }

--- a/path_test.go
+++ b/path_test.go
@@ -37,20 +37,20 @@ func TestPathTree_UnpackDataPaths(t *testing.T) {
 		},
 	}
 	noKeyRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     true,
-		IncludeFunctionRootPaths: false,
+		ExcludeDataRootPaths:     false,
+		ExcludeFunctionRootPaths: true,
 		StopAtTerminals:          false,
 		IncludeKeys:              false,
 	}
 	withKeyRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     true,
-		IncludeFunctionRootPaths: false,
+		ExcludeDataRootPaths:     false,
+		ExcludeFunctionRootPaths: true,
 		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}
 	noDataRootRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     false,
-		IncludeFunctionRootPaths: false,
+		ExcludeDataRootPaths:     true,
+		ExcludeFunctionRootPaths: true,
 		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}
@@ -81,14 +81,14 @@ func TestPathTree_UnpackFuncPaths(t *testing.T) {
 	}
 
 	noDataRootRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     false,
-		IncludeFunctionRootPaths: true,
+		ExcludeDataRootPaths:     true,
+		ExcludeFunctionRootPaths: false,
 		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}
 	noFunctionsRootRequirements := expressions.UnpackRequirements{
-		IncludeDataRootPaths:     true,
-		IncludeFunctionRootPaths: false,
+		ExcludeDataRootPaths:     false,
+		ExcludeFunctionRootPaths: true,
 		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -39,19 +39,16 @@ func TestPathTree_UnpackDataPaths(t *testing.T) {
 	noKeyRequirements := expressions.UnpackRequirements{
 		ExcludeDataRootPaths:     false,
 		ExcludeFunctionRootPaths: true,
-		StopAtTerminals:          false,
 		IncludeKeys:              false,
 	}
 	withKeyRequirements := expressions.UnpackRequirements{
 		ExcludeDataRootPaths:     false,
 		ExcludeFunctionRootPaths: true,
-		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}
 	noDataRootRequirements := expressions.UnpackRequirements{
 		ExcludeDataRootPaths:     true,
 		ExcludeFunctionRootPaths: true,
-		StopAtTerminals:          false,
 		IncludeKeys:              true,
 	}
 	pathsWithoutKeys := pathTree.Unpack(noKeyRequirements)
@@ -83,14 +80,10 @@ func TestPathTree_UnpackFuncPaths(t *testing.T) {
 	noDataRootRequirements := expressions.UnpackRequirements{
 		ExcludeDataRootPaths:     true,
 		ExcludeFunctionRootPaths: false,
-		StopAtTerminals:          false,
-		IncludeKeys:              true,
 	}
 	noFunctionsRootRequirements := expressions.UnpackRequirements{
 		ExcludeDataRootPaths:     false,
 		ExcludeFunctionRootPaths: true,
-		StopAtTerminals:          false,
-		IncludeKeys:              true,
 	}
 
 	pathsWithoutDataRoot := pathTree.Unpack(noDataRootRequirements)

--- a/path_test.go
+++ b/path_test.go
@@ -8,33 +8,29 @@ import (
 )
 
 func TestPathTree_Unpack(t *testing.T) {
-	paths := expressions.PathTree{
-		"foo",
-		[]*expressions.PathTree{
+	pathTree := expressions.PathTree{
+		PathItem:   "foo",
+		Extraneous: []any{"a"},
+		Subtrees: []*expressions.PathTree{
 			{
 				"bar",
+				[]any{},
 				nil,
 			},
 			{
 				"baz",
+				[]any{0},
 				nil,
 			},
 		},
-	}.Unpack()
+	}
+	paths := pathTree.Unpack(false)
+	pathsWithExtranous := pathTree.Unpack(true)
 
-	assert.Equals(
-		t,
-		len(paths),
-		2,
-	)
-	assert.Equals(
-		t,
-		paths[0].String(),
-		"foo.bar",
-	)
-	assert.Equals(
-		t,
-		paths[1].String(),
-		"foo.baz",
-	)
+	assert.Equals(t, len(paths), 2)
+	assert.Equals(t, len(pathsWithExtranous), 2)
+	assert.Equals(t, paths[0].String(), "foo.bar")
+	assert.Equals(t, pathsWithExtranous[0].String(), "foo.a.bar")
+	assert.Equals(t, paths[1].String(), "foo.baz")
+	assert.Equals(t, pathsWithExtranous[1].String(), "foo.a.baz.0")
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR addresses several things:
- Webb's former comments regarding redundancy in the bracket access code #19
-  Improved testing of dependency code. The coverage is now over 90% and hits several missing cases. Some of which were not perfectly implemented.
- Used a new design for the recursive dependency resolution. The new design is more clearly documented, and has two main path return types. One is the type that can be chained with dot notation or bracket access, and the list of completed paths.
- Created the concept of "extraneous" nodes. This is basically when we include information beyond the info necessary to resolve the dependency connection, like indexes and paths within any types.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).