### PR TITLE
Use correct parser for 64 bit integers

### DIFF
--- a/internal/ast/recursive_descent_parser.go
+++ b/internal/ast/recursive_descent_parser.go
@@ -103,11 +103,11 @@ func (p *Parser) parseIntLiteral() (*IntLiteral, error) {
 	if p.currentToken.TokenID != IntLiteralToken {
 		return nil, &InvalidGrammarError{FoundToken: p.currentToken, ExpectedTokens: []TokenID{IntLiteralToken}}
 	}
-	parsedInt, err := strconv.Atoi(p.currentToken.Value)
+	parsedInt, err := strconv.ParseInt(p.currentToken.Value, 10, 0)
 	if err != nil {
 		return nil, err // Should not fail if the parser is set up correctly
 	}
-	literal := &IntLiteral{IntValue: int64(parsedInt)}
+	literal := &IntLiteral{IntValue: parsedInt}
 	err = p.advanceToken()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes introduced with this PR

The old parser was more efficient, but only returned an int, which could theoretically lead to problems on 32 bit systems.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).