### PR TITLE
Raw Strings and Schema Fix

### DIFF
--- a/expression_data_test.go
+++ b/expression_data_test.go
@@ -1,6 +1,9 @@
 package expressions_test
 
-import "go.flow.arcalot.io/pluginsdk/schema"
+import (
+	"go.flow.arcalot.io/pluginsdk/schema"
+	"regexp"
+)
 
 var testScope = schema.NewScopeSchema(
 	schema.NewObjectSchema(
@@ -49,6 +52,16 @@ var testScope = schema.NewScopeSchema(
 			),
 			"simple_str": schema.NewPropertySchema(
 				schema.NewStringSchema(nil, nil, nil),
+				nil,
+				true,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			),
+			"restrictive_str": schema.NewPropertySchema(
+				schema.NewStringSchema(nil, nil, regexp.MustCompile(`^a$`)),
 				nil,
 				true,
 				nil,

--- a/expression_type_test.go
+++ b/expression_type_test.go
@@ -235,6 +235,18 @@ func TestTypeResolution_BinaryConcatenateStrings(t *testing.T) {
 	assert.Equals[schema.Type](t, typeResult, schema.NewStringSchema(nil, nil, nil))
 }
 
+func TestTypeResolution_WithStrictSchemas(t *testing.T) {
+	// In this example, we're going to reference schemas that have regular expressions that
+	// no longer apply when appended together.
+	// Use the strict schema for both left and right sides to ensure neither the left nor the right's
+	// strict schema is retained.
+	expr, err := expressions.New(`$.restrictive_str + $.restrictive_str`)
+	assert.NoError(t, err)
+	typeResult, err := expr.Type(testScope, nil, nil)
+	assert.NoError(t, err)
+	assert.Equals[schema.Type](t, typeResult, schema.NewStringSchema(nil, nil, nil))
+}
+
 func TestTypeResolution_BinaryMathHomogeneousIntReference(t *testing.T) {
 	// Two ints added should give an int. One int is a reference.
 	expr, err := expressions.New("5 + $.simple_int")

--- a/internal/ast/recursive_descent_parser.go
+++ b/internal/ast/recursive_descent_parser.go
@@ -164,7 +164,9 @@ func (p *Parser) parseStringLiteral() (*StringLiteral, error) {
 	// The literal token includes the "", so trim the ends off.
 	parsedString := p.currentToken.Value[1 : len(p.currentToken.Value)-1]
 	// Replace escaped characters
-	parsedString = escapeReplacer.Replace(parsedString)
+	if p.currentToken.TokenID != RawStringLiteralToken {
+		parsedString = escapeReplacer.Replace(parsedString)
+	}
 	// Now create the literal itself and advance the token.
 	literal := &StringLiteral{StrValue: parsedString}
 	err := p.advanceToken()
@@ -495,7 +497,7 @@ func (p *Parser) parseNegationOperation() (Node, error) {
 	return p.parseLeftUnaryExpression([]TokenID{NegationToken}, p.parseValueOrAccessExpression)
 }
 
-var literalTokens = []TokenID{StringLiteralToken, IntLiteralToken, BooleanLiteralToken, FloatLiteralToken}
+var literalTokens = []TokenID{StringLiteralToken, RawStringLiteralToken, IntLiteralToken, BooleanLiteralToken, FloatLiteralToken}
 var identifierTokens = []TokenID{IdentifierToken, RootAccessToken}
 var validRootValueOrAccessStartTokens = append(literalTokens, identifierTokens...)
 var validValueOrAccessStartTokens = append(validRootValueOrAccessStartTokens, CurrentObjectAccessToken)
@@ -515,7 +517,7 @@ func (p *Parser) parseValueOrAccessExpression() (Node, error) {
 	// A value or access expression can start with a literal, or an identifier.
 	// If an identifier, it can lead to a chain or a function.
 	switch p.currentToken.TokenID {
-	case StringLiteralToken:
+	case StringLiteralToken, RawStringLiteralToken:
 		literalNode, err = p.parseStringLiteral()
 	case IntLiteralToken:
 		literalNode, err = p.parseIntLiteral()

--- a/internal/ast/recursive_descent_parser.go
+++ b/internal/ast/recursive_descent_parser.go
@@ -103,11 +103,11 @@ func (p *Parser) parseIntLiteral() (*IntLiteral, error) {
 	if p.currentToken.TokenID != IntLiteralToken {
 		return nil, &InvalidGrammarError{FoundToken: p.currentToken, ExpectedTokens: []TokenID{IntLiteralToken}}
 	}
-	parsedInt, err := strconv.Atoi(p.currentToken.Value)
+	parsedInt, err := strconv.ParseInt(p.currentToken.Value, 10, 0)
 	if err != nil {
 		return nil, err // Should not fail if the parser is set up correctly
 	}
-	literal := &IntLiteral{IntValue: int64(parsedInt)}
+	literal := &IntLiteral{IntValue: parsedInt}
 	err = p.advanceToken()
 	if err != nil {
 		return nil, err

--- a/internal/ast/tokenizer.go
+++ b/internal/ast/tokenizer.go
@@ -16,7 +16,8 @@ const (
 	// Supports the string format used in golang, and will include
 	// the " before and after the contents of the string.
 	// Characters can be escaped the common way with a backslash.
-	StringLiteralToken TokenID = "string"
+	StringLiteralToken    TokenID = "string"
+	RawStringLiteralToken TokenID = "raw-string"
 	// IntLiteralToken represents an integer token. Must not start with 0.
 	IntLiteralToken TokenID = "int"
 	// FloatLiteralToken represents a float token.
@@ -108,7 +109,8 @@ var tokenPatterns = []tokenPattern{
 	{FloatLiteralToken, regexp.MustCompile(`^\d+\.\d*(?:[eE][+-]?\d+)?$`)}, // Like an integer, but with a period and digits after.
 	{IntLiteralToken, regexp.MustCompile(`^(?:0|[1-9]\d*)$`)},              // Note: numbers that start with 0 are identifiers.
 	{IdentifierToken, regexp.MustCompile(`^\w+$`)},                         // Any valid object name
-	{StringLiteralToken, regexp.MustCompile(`^(?:".*"|'.*')$`)},            // "string example"
+	{StringLiteralToken, regexp.MustCompile(`^(?:".*"|'.*')$`)},            // "string example" 'alternative'
+	{RawStringLiteralToken, regexp.MustCompile("^`.*`$")},                  // `raw string`
 	{BracketAccessDelimiterStartToken, regexp.MustCompile(`^\[$`)},         // the [ in map["key"]
 	{BracketAccessDelimiterEndToken, regexp.MustCompile(`^]$`)},            // the ] in map["key"]
 	{ParenthesesStartToken, regexp.MustCompile(`^\($`)},                    // (

--- a/internal/ast/tokenizer_test.go
+++ b/internal/ast/tokenizer_test.go
@@ -216,7 +216,7 @@ func TestTokenizer_BooleanLiterals(t *testing.T) {
 }
 
 func TestTokenizer_StringLiteral(t *testing.T) {
-	input := `"" "a" "a\"b"`
+	input := `"" "a" "a\"b"` + " `raw_str/\\`"
 	tokenizer := initTokenizer(input, filename)
 	assert.Equals(t, tokenizer.hasNextToken(), true)
 	tokenVal, err := tokenizer.getNext()
@@ -233,6 +233,11 @@ func TestTokenizer_StringLiteral(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equals(t, tokenVal.TokenID, StringLiteralToken)
 	assert.Equals(t, tokenVal.Value, `"a\"b"`)
+	assert.Equals(t, tokenizer.hasNextToken(), true)
+	tokenVal, err = tokenizer.getNext()
+	assert.NoError(t, err)
+	assert.Equals(t, tokenVal.TokenID, RawStringLiteralToken)
+	assert.Equals(t, tokenVal.Value, "`raw_str/\\`")
 	assert.Equals(t, tokenizer.hasNextToken(), false)
 }
 


### PR DESCRIPTION
## Changes introduced with this PR

This PR does two things:
- Adds raw strings for when you don't want arca to do the escaping for you.
- Adds schema changes to remove restrictions from operand schemas.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).